### PR TITLE
Switch from bcrypt to bcrypt-nodejs to ease install on Windows

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -1,5 +1,5 @@
 var mongoose = require('mongoose');
-var bcrypt = require('bcrypt');
+var bcrypt = require('bcrypt-nodejs');
 
 var userSchema = new mongoose.Schema({
   email: { type: String, unique: true },
@@ -30,7 +30,7 @@ userSchema.pre('save', function(next) {
   bcrypt.genSalt(SALT_FACTOR, function(err, salt) {
     if (err) return next(err);
 
-    bcrypt.hash(user.password, salt, function(err, hash) {
+    bcrypt.hash(user.password, salt, null, function(err, hash) {
       if (err) return next(err);
       user.password = hash;
       next();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "async": "~0.2.10",
-    "bcrypt": "~0.7.7",
+    "bcrypt-nodejs": "~0.0.3",
     "cheerio": "~0.13.1",
     "express": "~3.4.8",
     "express-flash": "~0.0.2",


### PR DESCRIPTION
Proposed change: Switch to **bcrypt-nodejs** which is implemented in JS rather than native. This avoids the need for native compilation and makes installation much easier on Windows.
