### PR TITLE
Better approach to Twitter email and Facebook location

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,7 +79,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 app.use(function(req, res, next) {
   res.locals.user = req.user;
-  res.locals.token = req.csrfToken(); 
+  res.locals.token = req.csrfToken();
   next();
 });
 app.use(flash());
@@ -126,7 +126,7 @@ app.get('/api/paypal/cancel', apiController.getPayPalCancel);
  * OAuth routes for sign-in.
  */
 
-app.get('/auth/facebook', passport.authenticate('facebook', { scope: 'email' }));
+app.get('/auth/facebook', passport.authenticate('facebook', { scope: ['email', 'user_location'] }));
 app.get('/auth/facebook/callback', passport.authenticate('facebook', { successRedirect: '/', failureRedirect: '/login' }));
 app.get('/auth/github', passport.authenticate('github'));
 app.get('/auth/github/callback', passport.authenticate('github', { successRedirect: '/', failureRedirect: '/login' }));

--- a/config/passport.js
+++ b/config/passport.js
@@ -68,6 +68,7 @@ passport.use(new FacebookStrategy(secrets.facebook, function (req, accessToken, 
       user.profile.name = profile.displayName;
       user.profile.gender = profile._json.gender;
       user.profile.picture = 'https://graph.facebook.com/' + profile.id + '/picture?type=large';
+      user.profile.location = profile._json.location.name;
       user.save(function(err) {
         done(err, user);
       });
@@ -147,7 +148,10 @@ passport.use(new TwitterStrategy(secrets.twitter, function(req, accessToken, tok
     User.findOne({ twitter: profile.id }, function(err, existingUser) {
       if (existingUser) return done(null, existingUser);
       var user = new User();
-      user.email = profile.displayName;
+      // Twitter will not provide an email address.  Period.
+      // But a person’s twitter username is guaranteed to be unique
+      // so we can “fake” a twitter email address as follows:
+      user.email = profile.username + "@twitter.com";
       user.twitter = profile.id;
       user.tokens.push({ kind: 'twitter', accessToken: accessToken, tokenSecret: tokenSecret });
       user.profile.name = profile.displayName;


### PR DESCRIPTION
This does a bit better at loading the twitter email field - twitter's API will not provide an email address but if we need something in this field it should better approximate an email address.  A twitter username is unique so we can use that as the root + @twitter.com.

I also added a location from facebook so we have more fields filled.  
