### PR TITLE
Check for null email before creating gravatar url

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -56,6 +56,11 @@ userSchema.methods.comparePassword = function(candidatePassword, cb) {
 userSchema.methods.gravatar = function(size, defaults) {
   if (!size) size = 200;
   if (!defaults) defaults = 'retro';
+
+  if(!this.email) {
+    return 'https://gravatar.com/avatar/?s=' + size + '&d=' + defaults;
+  }
+
   var md5 = crypto.createHash('md5').update(this.email);
   return 'https://gravatar.com/avatar/' + md5.digest('hex').toString() + '?s=' + size + '&d=' + defaults;
 };


### PR DESCRIPTION
When logging in using Github authentication the User model that is created has it's email set to null. So it is unable to create the md5 hash for the url. Fixed to return a default image if this it occurs.

Fixes Issue #69
