### PR TITLE
remove crypto module and add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "hackathon-starter",
   "version": "0.0.0",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/sahat/hackathon-starter.git"
+  },
   "scripts": {
     "start": "node app.js",
     "test": "mocha"


### PR DESCRIPTION
- Nodejs has a core module named crypto, why we cant use that directly instead of a separate npm package.
  - Removes warning `crypto@0.0.3 crypto is also the name of a node core module.` 
- Add repository field to package.json 
  - Removes warning `package.json hackathon-starter@0.0.0 No repository field.`
