### PR TITLE
Add Security Headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,6 +79,8 @@ app.use(express.csrf());
 app.use(passport.initialize());
 app.use(passport.session());
 app.use(function(req, res, next) {
+  res.header('X-XSS-Protection', '1; mode=block');
+  res.header('X-Frame-Options', 'SAMEORIGIN');
   res.locals.user = req.user;
   res.locals.token = req.csrfToken();
   res.locals.secrets = secrets;


### PR DESCRIPTION
Added two Security Headers.
- Added `x-frame-options: SAMEORIGIN` to prevent websites to include an iframe of the site. This limits the ability of other sites to perform clickjacking attacks. This still allows developers to put iframes on their site that have the same origin.
- Added `x-xss-protection: 1; mode=block` to enable XSS protection on the browser.
