### PR TITLE
stores lowercase email for gravatar

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -3,7 +3,7 @@ var bcrypt = require('bcrypt-nodejs');
 var crypto = require('crypto');
 
 var userSchema = new mongoose.Schema({
-  email: { type: String, unique: true },
+  email: { type: String, unique: true, lowercase: true },
   password: String,
 
   facebook: String,


### PR DESCRIPTION
At the moment the starter app stores email addresses case-sensitively.
The `gravatar` api requires them to be [lowercase](https://de.gravatar.com/site/implement/hash/), so I changed the `mongo` settings to store email as lowercase. This avoids wrong results for emails (unintentionally) inputted with some uppercase characters.
