### PR TITLE
Corrected buildAssets to builtAssets directory in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ Thumbs.db
 
 public/css/styles.css
 
-buildAssets
+builtAssets


### PR DESCRIPTION
The build directory for assets seems to be builtAssets and not buildAssets. Correcting the .gitignore file to exclude these generated files.
