### PR TITLE
bump express-validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "csso": "~1.3.11",
     "express": "~3.4.8",
     "express-flash": "~0.0.2",
-    "express-validator": "~1.0.1",
+    "express-validator": "~2.1.1",
     "fbgraph": "~0.2.9",
     "github-api": "~0.7.0",
     "jade": "~1.3.0",


### PR DESCRIPTION
1.0.1 lacks of some fundamental features like .matches
