### PR TITLE
Mail providers configuration bugfix

### DIFF
--- a/config/secrets.js
+++ b/config/secrets.js
@@ -23,12 +23,12 @@ module.exports = {
   sessionSecret: process.env.SESSION_SECRET || 'Your Session Secret goes here',
 
   mailgun: {
-    login: process.env.MAILGUN_LOGIN || 'postmaster@sandbox697fcddc09814c6b83718b9fd5d4e5dc.mailgun.org',
+    user: process.env.MAILGUN_LOGIN || 'postmaster@sandbox697fcddc09814c6b83718b9fd5d4e5dc.mailgun.org',
     password: process.env.MAILGUN_PASSWORD || '29eldds1uri6'
   },
   
   mandrill: {
-    login: process.env.MANDRILL_LOGIN || 'hackathonstarterdemo',
+    user: process.env.MANDRILL_LOGIN || 'hackathonstarterdemo',
     password: process.env.MANDRILL_PASSWORD || 'E1K950_ydLR4mHw12a0ldA'
   },
 


### PR DESCRIPTION
After changing email service provider with Generator I got the following error:

```
Error: Authentication required, invalid details provided
at SMTPTransport.sendMail (/home/raido/hackathon-starter/node_modules/nodemailer/lib/engines/smtp.js:124:22)
at Transport.sendMailWithTransport (/home/raido/hackathon-starter/node_modules/nodemailer/lib/transport.js:80:20)
at Nodemailer.sendMail (/home/raido/hackathon-starter/node_modules/nodemailer/lib/nodemailer.js:206:20)
at /home/raido/hackathon-starter/node_modules/nodemailer/lib/nodemailer.js:68:20
at Nodemailer.validateSettings (/home/raido/hackathon-starter/node_modules/nodemailer/lib/nodemailer.js:193:5)
at sendMail (/home/raido/hackathon-starter/node_modules/nodemailer/lib/nodemailer.js:62:12)
at Transport.transport.sendMail (/home/raido/hackathon-    starter/node_modules/nodemailer/lib/nodemailer.js:30:9)
at /home/raido/hackathon-starter/controllers/user.js:372:21
at fn (/home/raido/hackathon-starter/node_modules/async/lib/async.js:641:34)
at Object._onImmediate (/home/raido/hackathon-starter/node_modules/async/lib/async.js:557:34)
```

Generator changes `contact.js` and `users.js` and expects the key `user` for all mail service providers configuration.

Did the easy fix and edited `secrets.js`.

Raido
