### PR TITLE
Simplify deployment procedure to Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1073,10 +1073,18 @@ Deployment
 ----------
 
 Once you are ready to deploy your app, you will need to create an account with a cloud platform to host it. These are not
-the only choices, but they are my top picks. Create an account with **MongoLab** and then pick one of the 4 providers
-below. Once again, there are plenty of other choices and you are not limited to just the ones listed below. From my
-experience, **Heroku** is the easiest to get started with, it will automatically restart your node.js process when it crashes, custom domain support on free accounts and zero-downtime deployments.
+the only choices, but they are my top picks. From my experience, **Heroku** is the easiest to get started with, it will automatically restart your node.js process when it crashes, custom domain support on free accounts and zero-downtime deployments. Additionally, you can create an account with **MongoLab** and then pick one of the 3 providers
+below. Once again, there are plenty of other choices and you are not limited to just the ones listed below. 
 
+###One step deployment with Heroku
+<img src="http://blog.exadel.com/wp-content/uploads/2013/10/heroku-Logo-1.jpg" width="200">
+- Download and install [Heroku Toolbelt](https://toolbelt.heroku.com/)
+- In terminal, run `heroku login` and enter your Heroku credentials
+- From *your app* directory run `heroku create`
+- Run `heroku addons:add mongolab` to set up Mongo and configure your environment variables
+- Lastly, do `git push heroku master`.  Done!
+
+###Deploying with MongoLab and another cloud provider
 <img src="http://i.imgur.com/7KnCa5a.png" width="200">
 - Open [mongolab.com](https://mongolab.com) website
 - Click the yellow **Sign up** button
@@ -1097,11 +1105,6 @@ experience, **Heroku** is the easiest to get started with, it will automatically
 
 > **:exclamation:Note:** As an alternative to MongoLab, there is also [MongoHQ](http://www.mongohq.com/home).
 
-<img src="http://blog.exadel.com/wp-content/uploads/2013/10/heroku-Logo-1.jpg" width="200">
-- Download and install [Heroku Toolbelt](https://toolbelt.heroku.com/osx)
-- In terminal, run `heroku login` and enter your Heroku credentials
-- From *your app* directory run `heroku create`, followed by `git push heroku master`
-- Done!
 
 <img src="http://www.opencloudconf.com/images/openshift_logo.png" width="200">
 - First, install this Ruby gem: `sudo gem install rhc` :gem:

--- a/config/secrets.js
+++ b/config/secrets.js
@@ -18,7 +18,7 @@
 
 module.exports = {
 
-  db: process.env.MONGODB|| 'mongodb://localhost:27017/test',
+  db: process.env.MONGOLAB_URI || process.env.MONGODB || 'mongodb://localhost:27017/test',
 
   sessionSecret: process.env.SESSION_SECRET || 'Your Session Secret goes here',
 


### PR DESCRIPTION
Having to configure the separate account with MongoLab is somewhat tedious and unnecessary if you are deploying to Heroku, as there exist MongoLab & MongoHQ addons which simplify the process quite a bit (no signups!).   These are very minor changes that just implement the plugins, but the net effect is that someone can fork hackathon-starter then immediately deploy it to Heroku and have it work.  Having done two hackathons already using this repo, I can say that having hackathon-starter live within 20 seconds is a very inspiring way to start a hackathon =)

I was considering editing the docs to place the deployment details toward the front of the readme to show how easy it is to do. I figured I would wait to see your response first -- let me know.
