### PR TITLE
Fixing deprecation warning in mongo-connect 0.5

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,7 +79,7 @@ app.use(session({
   resave: true,
   saveUninitialized: true,
   secret: secrets.sessionSecret,
-  store: new MongoStore({ url: secrets.db, auto_reconnect: true })
+  store: new MongoStore({ url: secrets.db, autoReconnect: true })
 }));
 app.use(passport.initialize());
 app.use(passport.session());


### PR DESCRIPTION
Before:

``` javascript
$ node app.js
connect-mongo deprecated auto_reconnect option is deprecated. Use autoReconnect instead app.js:82:10
Express server listening on port 3000 in development mode
```

After:

``` javascript
$ node app.js
Express server listening on port 3000 in development mode
```

mongo-connect commit that made the change: https://github.com/kcbanner/connect-mongo/commit/663df675b6a5f9daaf937294abe2e4ba4ac7a1f2
