### PR TITLE
Updating Flatly theme to 3.3.2

### DIFF
--- a/public/css/themes/flatly/_styles.scss
+++ b/public/css/themes/flatly/_styles.scss
@@ -1,4 +1,4 @@
-// Flatly 3.3.0
+// Flatly 3.3.2
 // Bootswatch
 // -----------------------------------------------------
 
@@ -26,18 +26,18 @@
   }
 
   &-brand {
-    padding: 18.5px 15px 20.5px;
+    line-height: 1;
   }
 }
 
 // Buttons ====================================================================
 
 .btn:active {
-  .box-shadow(none);
+  @include box-shadow(none);
 }
 
 .btn-group.open .dropdown-toggle {
-  .box-shadow(none);
+  @include box-shadow(none);
 }
 
 // Typography =================================================================
@@ -86,7 +86,9 @@ table,
   .info {
     color: #fff;
 
-    a {
+    > th > a,
+    > td > a,
+    > a {
       color: #fff;
     }
   }
@@ -115,10 +117,10 @@ table,
 .form-control,
 input, {
   border-width: 2px;
-  .box-shadow(none);
+  @include box-shadow(none);
 
   &:focus {
-    .box-shadow(none);
+    @include box-shadow(none);
   }
 }
 
@@ -237,7 +239,7 @@ input, {
 
 .progress {
   height: 10px;
-  .box-shadow(none);
+  @include box-shadow(none);
   .progress-bar {
     font-size: 10px;
     line-height: 10px;
@@ -247,7 +249,7 @@ input, {
 // Containers =================================================================
 
 .well {
-  .box-shadow(none);
+  @include box-shadow(none);
 }
 
 a.list-group-item {
@@ -273,7 +275,7 @@ a.list-group-item {
     &.active {
       background-color: $state-warning-bg;
     }
-
+    
     &.active:hover,
     &.active:focus {
       background-color: darken($state-warning-bg, 5%);
@@ -284,7 +286,7 @@ a.list-group-item {
     &.active {
       background-color: $state-danger-bg;
     }
-
+    
     &.active:hover,
     &.active:focus {
       background-color: darken($state-danger-bg, 5%);

--- a/public/css/themes/flatly/_variables.scss
+++ b/public/css/themes/flatly/_variables.scss
@@ -1,4 +1,4 @@
-// Flatly 3.3.0
+// Flatly 3.3.2
 // Variables
 // --------------------------------------------------
 
@@ -98,7 +98,7 @@ $padding-small-horizontal:  9px;
 $padding-xs-vertical:       1px;
 $padding-xs-horizontal:     5px;
 
-$line-height-large:         1.33;
+$line-height-large:         1.3333333; // extra decimals for Win 8.1 Chrome
 $line-height-small:         1.5;
 
 $border-radius-base:        4px;
@@ -186,6 +186,7 @@ $input-border:                   #dce4ec;
 
 // TODO: Rename `$input-border-radius` to `$input-border-radius-base` in v4
 //** Default `.form-control` border radius
+// This has no effect on `<select>`s in some browsers, due to the limited stylability of `<select>`s in CSS.
 $input-border-radius:            $border-radius-base;
 //** Large `.form-control` border radius
 $input-border-radius-large:      $border-radius-large;
@@ -235,7 +236,7 @@ $dropdown-link-color:            $gray-dark;
 //** Hover color for dropdown links.
 $dropdown-link-hover-color:      #fff;
 //** Hover background for dropdown links.
-$dropdown-link-hover-bg:         $dropdown-link-active-bg;
+$dropdown-link-hover-bg:         $component-active-bg;
 
 //** Active dropdown menu item text color.
 $dropdown-link-active-color:     #fff;
@@ -243,10 +244,10 @@ $dropdown-link-active-color:     #fff;
 $dropdown-link-active-bg:        $component-active-bg;
 
 //** Disabled dropdown menu item background color.
-$dropdown-link-disabled-color:   $text-muted;
+$dropdown-link-disabled-color:   $gray-light;
 
 //** Text color for headers within dropdown menus.
-$dropdown-header-color:          $text-muted;
+$dropdown-header-color:          $gray-light;
 
 //** Deprecated `$dropdown-caret-color` as of v3.1.0
 $dropdown-caret-color:           #000;
@@ -449,7 +450,7 @@ $pagination-active-bg:                 darken($brand-success, 15%);
 $pagination-active-border:             transparent;
 
 $pagination-disabled-color:            $gray-lighter;
-$pagination-disabled-bg:               lighten($brand-success, 15%);;
+$pagination-disabled-bg:               lighten($brand-success, 15%);
 $pagination-disabled-border:           transparent;
 
 


### PR DESCRIPTION
Current version was using variables before they had been declared, and the box-shadow function needed to be included in order to work