### PR TITLE
Fix radio button alignment on small screens

### DIFF
--- a/views/account/profile.jade
+++ b/views/account/profile.jade
@@ -17,10 +17,10 @@ block content
     .form-group
       label.col-sm-2.control-label(for='gender') Gender
       .col-sm-4
-        label.radio
+        label.radio.col-sm-4
           input(type='radio', checked=user.profile.gender=='male', name='gender', value='male', data-toggle='radio')
           span Male
-        label.radio
+        label.radio.col-sm-4
           input(type='radio', checked=user.profile.gender=='female', name='gender', value='female', data-toggle='radio')
           span Female
     .form-group


### PR DESCRIPTION
When viewing /account in a window less than 768px, the radio buttons are positioned off the page:
![image](https://cloud.githubusercontent.com/assets/9045165/6879872/d83dcd56-d4ce-11e4-9737-3b95ec3ad9cd.png)

Adding the bootstap column class used on other form fields on the page to the radio buttons moves them onto the page and in line with the rest of the form..