### PR TITLE
Add focus state declaration to footer links. Closes #258

### DIFF
--- a/public/css/themes/modern.less
+++ b/public/css/themes/modern.less
@@ -23,7 +23,8 @@ footer {
   color: #fff;
   background-color: @gray-darker;
 
-  a:hover {
+  a:hover,
+  a:focus {
     color: #fff;
   }
 }


### PR DESCRIPTION
This small PR adds declaration for links `:focus` state in order to remove issue with links having the same color as background in the `modern` theme.
Thanks!
![20150403225311](https://cloud.githubusercontent.com/assets/14539/6988723/74ad8264-da54-11e4-8441-7f232e89f0ad.jpg)
