### PR TITLE
Updates for one-step-deployment to Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,7 +1116,7 @@ listed below.
 - Download and install [Heroku Toolbelt](https://toolbelt.heroku.com/)
 - In terminal, run `heroku login` and enter your Heroku credentials
 - From *your app* directory run `heroku create`
-- Run `heroku addons:add mongolab` to set up Mongo and configure your environment variables
+- Run `heroku addons:create mongolab`.  This will set up the MongoLab add-on and configure the `MONGOLAB_URI` environment variable in your Heroku app for you.
 - Lastly, do `git push heroku master`.  Done!
 
 **Note:** To install Heroku add-ons your account must be verified.

--- a/config/secrets.js
+++ b/config/secrets.js
@@ -21,7 +21,7 @@
 
 module.exports = {
 
-  db: process.env.MONGODB || 'mongodb://localhost:27017/test',
+  db: process.env.MONGODB || process.env.MONGOLAB_URI || 'mongodb://localhost:27017/test',
 
   sessionSecret: process.env.SESSION_SECRET || 'Your Session Secret goes here',
 


### PR DESCRIPTION
Updates to the docs for Heroku one-click deploy per #294.

`heroku addons:add` was deprecated and replaced by `heroku addons:create`

I also updated `secrets.js` to automatically pick up the `MONGOLAB_URI` environment var set by the Mongolab add-on in the Heroku environment to make deployment dead-simple.