### PR TITLE
swap ion icon with font-awesome in partials

### DIFF
--- a/views/partials/flash.jade
+++ b/views/partials/flash.jade
@@ -1,7 +1,7 @@
 if messages.errors
   .alert.alert-danger.fade.in
     button.close(type='button', data-dismiss='alert')
-      span.ion-close-circled
+      i.fa.fa-times-circle-o
     for error in messages.errors
       div= error.msg
 if messages.info


### PR DESCRIPTION
the flash error message used `span.ion-close-circled` for the close circle. Other message already used the font-awesome version `i.fa.fa-times-circle-o`.