### PR TITLE
Remove multer from README.md list of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,6 @@ List of Packages
 | cookie-parser                   | Express 4 middleware.                                                 |
 | express-session                 | Express 4 middleware.                                                 |
 | morgan                          | Express 4 middleware.                                                 |
-| multer                          | Express 4 middleware.                                                 |
 | compression                     | Express 4 middleware.                                                 |
 | errorhandler                    | Express 4 middleware.                                                 |
 | method-override                 | Express 4 middleware.                                                 |


### PR DESCRIPTION
According to changelog the multer package is no longer included.