### PR TITLE
disabled horizontal resizing of textarea

### DIFF
--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -31,6 +31,13 @@ footer {
   }
 }
 
+// Input Fields
+// -------------------------
+
+textarea {
+  resize: vertical;
+}
+
 // Navbar
 // -------------------------
 


### PR DESCRIPTION
removed horizontal `textarea` resizing as not to break responsiveness when adjusted.


## Before
![2015-12-29-15 25 40](https://cloud.githubusercontent.com/assets/8713153/12041607/c6bf6034-ae40-11e5-87e7-783e54cd3035.png)



## After
![2015-12-29-15 25 45](https://cloud.githubusercontent.com/assets/8713153/12041622/df30ac7c-ae40-11e5-8a26-1ce371f2826b.png)
