### PR TITLE
Missing public profile and email after switching to another Facebook App ID and Secret #348

### DIFF
--- a/config/secrets.js
+++ b/config/secrets.js
@@ -53,6 +53,7 @@ module.exports = {
     clientID: process.env.FACEBOOK_ID || '754220301289665',
     clientSecret: process.env.FACEBOOK_SECRET || '41860e58c256a3d7ad8267d3c1939a4a',
     callbackURL: '/auth/facebook/callback',
+    profileFields: ['name', 'email', 'link', 'locale', 'timezone'],
     passReqToCallback: true
   },
 

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -111,7 +111,7 @@ exports.getFacebook = function(req, res, next) {
   graph.setAccessToken(token.accessToken);
   async.parallel({
     getMe: function(done) {
-      graph.get(req.user.facebook, function(err, me) {
+      graph.get(req.user.facebook + "?fields=id,name,email,first_name,last_name,gender,link,locale,timezone", function(err, me) {
         done(err, me);
       });
     },


### PR DESCRIPTION
This fix is required for integrating with the new Facebook Graph API version 2.5 or above.

- added the profile fields in /me request for most recent Facebook Graph API