### PR TITLE
improve redirect after login

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,8 +95,12 @@ app.use(function(req, res, next) {
   next();
 });
 app.use(function(req, res, next) {
-  // After successful login, redirect back to /api, /contact or /
-  if (/(api)|(contact)|(^\/$)/i.test(req.path)) {
+  // After successful login, redirect back to the intended page
+  if (req.user == undefined &&
+      req.path !== '/login' &&
+      req.path !== '/signup' &&
+      !req.path.match(/^\/auth/) &&
+      !req.path.match(/\./)) {
     req.session.returnTo = req.path;
   }
   next();


### PR DESCRIPTION
Instead of checking for explicit routes, this tries to exclude any unwanted routes and store anything else. All of the following 5 conditions have to be met in order to save the current path

1. User must not be logged in (saves some resources)
2. Route must not be `/login` (you don't want to get back to login after login)
3. Route must not be `/signup` (same reason as above)
4. Route must not start with `/auth` (same reason as above)
5. Path does not contain a dot (this usually matches a file and you don't want to be redirected to `favicon.ico`)