### PR TITLE
Dots should be allowed in email.

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -25,7 +25,7 @@ exports.getLogin = function(req, res) {
 exports.postLogin = function(req, res, next) {
   req.assert('email', 'Email is not valid').isEmail();
   req.assert('password', 'Password cannot be blank').notEmpty();
-  req.sanitize('email').normalizeEmail();
+  req.sanitize('email').normalizeEmail({remove_dots: false});
 
   var errors = req.validationErrors();
 
@@ -82,7 +82,7 @@ exports.postSignup = function(req, res, next) {
   req.assert('email', 'Email is not valid').isEmail();
   req.assert('password', 'Password must be at least 4 characters long').len(4);
   req.assert('confirmPassword', 'Passwords do not match').equals(req.body.password);
-  req.sanitize('email').normalizeEmail();
+  req.sanitize('email').normalizeEmail({remove_dots: false});
 
   var errors = req.validationErrors();
 
@@ -131,7 +131,7 @@ exports.getAccount = function(req, res) {
  */
 exports.postUpdateProfile = function(req, res, next) {
   req.assert('email', 'Please enter a valid email address.').isEmail();
-  req.sanitize('email').normalizeEmail();
+  req.sanitize('email').normalizeEmail({remove_dots: false});
 
   var errors = req.validationErrors();
 


### PR DESCRIPTION
Just my two cents. It's fairly common to have dots in the user's email address and it will appear to the user that they have not signed up since the email is normalized. My pull request allows for dots in the user's email but still removes plus. I can understand removing the plus since that can be "spammy".