### PR TITLE
Added easy clone support for ES5 variation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The easiest way to get started is to clone the repository:
 
 ```bash
 # Get the latest snapshot
-git clone --depth=1 https://github.com/sahat/hackathon-starter.git myproject
+git clone --depth=1 https://github.com/sahat/hackathon-starter.git -b es5 myproject
 
 # Change directory
 cd myproject


### PR DESCRIPTION
Fixed cloning instructions in README.md

Users can now easily clone the ES5 variation of the starter pack.