### PR TITLE
Fix redirect issue in the account page

### DIFF
--- a/app.js
+++ b/app.js
@@ -105,6 +105,9 @@ app.use(function(req, res, next) {
       !req.path.match(/^\/auth/) &&
       !req.path.match(/\./)) {
     req.session.returnTo = req.path;
+  } else if (req.user &&
+      req.path == '/account') {
+      req.session.returnTo = '/account';
   }
   next();
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackathon-starter",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/sahat/hackathon-starter.git"
@@ -55,7 +55,7 @@
     "stripe": "^4.11.0",
     "tumblr.js": "^1.1.1",
     "twilio": "^3.3.1-edge",
-    "twit": "^2.2.4",
+    "twit": "^2.2.5",
     "validator": "^5.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
If a user creates an account with an email address, then goes to `/account`, and links a social login page like Google+ at the bottom of the page, immediately after the  callback from Google+ the user will end up at `/` route (default) instead of /account since `req.session.returnTo` isn't set.

This pull request sets `req.session.returnTo` to `/account` if the request is already from an authenticated user and is from `/account` to have the user go back to the account page after a successful linking of a social login account.



While at it, I also put a minor version bump for twit dependency to explicitly call out the non vulnerable version at https://github.com/sahat/hackathon-starter/issues/546 and establish a line in the sand for when all items in that issue are cleared.