### PR TITLE
Fix Deprecation warning of mongoose.Promise 

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,6 +47,7 @@ const app = express();
 /**
  * Connect to MongoDB.
  */
+mongoose.Promise = global.Promise;
 mongoose.connect(process.env.MONGODB_URI || process.env.MONGOLAB_URI);
 mongoose.connection.on('connected', () => {
   console.log('%s MongoDB connection established!', chalk.green('✓'));


### PR DESCRIPTION
I noticed deprecation warning below when I run test and app debugging console.

> (node:34180) DeprecationWarning: Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html

To fix this warning I override mongoose's internal promise by node.js global promise function.

