### PR TITLE
Fix redirect issue in the account page

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,6 +106,9 @@ app.use(function(req, res, next) {
       !req.path.match(/^\/auth/) &&
       !req.path.match(/\./)) {
     req.session.returnTo = req.path;
+  } else if (req.user &&
+      req.path == '/account') {
+    req.session.returnTo = req.path;
   }
   next();
 });


### PR DESCRIPTION
If a user creates an account with an email address, then goes to `/account`, and links a social login page like Google+ at the bottom of the page, immediately after the  callback from Google+ the user will end up at `/` route (default) instead of /account since `req.session.returnTo` isn't set.

This pull request sets `req.session.returnTo` to `/account` if the request is already from an authenticated user and is from `/account` to have the user go back to the account page after a successful linking of a social login account.
