### PR TITLE
Adds link when developing locally on startup

### DIFF
--- a/app.js
+++ b/app.js
@@ -222,7 +222,8 @@ app.use(errorHandler());
  * Start Express server.
  */
 app.listen(app.get('port'), () => {
-  console.log('%s Express server listening on port %d in %s mode.', chalk.green('✓'), app.get('port'), app.get('env'));
+  const host = (app.get('env') === 'development') ? 'http://localhost:%d' : 'port %d';
+  console.log('%s Express server listening on ' + host + ' in %s mode.', chalk.green('✓'), app.get('port'), app.get('env'));
 });
 
 module.exports = app;


### PR DESCRIPTION
Adds a click-able link to the server address in the console (hold CMD on Mac, CTRL on Windows and click the link). Falls back to previous behaviour if the `env` is not set to `development`.

![image](https://cloud.githubusercontent.com/assets/1525669/19277149/a71e05e2-8fd0-11e6-9904-7ee6e069096d.png)
