### PR TITLE
Adapted fb request scope to current definition

### DIFF
--- a/app.js
+++ b/app.js
@@ -173,7 +173,7 @@ app.get('/auth/instagram', passport.authenticate('instagram'));
 app.get('/auth/instagram/callback', passport.authenticate('instagram', { failureRedirect: '/login' }), (req, res) => {
   res.redirect(req.session.returnTo || '/');
 });
-app.get('/auth/facebook', passport.authenticate('facebook', { scope: ['email', 'user_location'] }));
+app.get('/auth/facebook', passport.authenticate('facebook', { scope: ['email', 'public_profile'] }));
 app.get('/auth/facebook/callback', passport.authenticate('facebook', { failureRedirect: '/login' }), (req, res) => {
   res.redirect(req.session.returnTo || '/');
 });


### PR DESCRIPTION
Adapted fb request scope to match current scheme as previous one caused an error message (not all fields approved for app).

Properties requested are all covered by new definition: https://developers.facebook.com/docs/facebook-login/permissions/#reference-public_profile

Functionality is the same as before from what I can see.

Screenshot of error: 
![screen shot 2017-01-05 at 13 02 45](https://cloud.githubusercontent.com/assets/1608080/21680065/a3853ac6-d347-11e6-80c6-59a1f6f957d8.png)
