### PR TITLE
Remove async package and use built-in ES6 Promises

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1,4 +1,3 @@
-const async = require('async');
 const crypto = require('crypto');
 const nodemailer = require('nodemailer');
 const passport = require('passport');
@@ -250,51 +249,52 @@ exports.postReset = (req, res, next) => {
     return res.redirect('back');
   }
 
-  async.waterfall([
-    function resetPassword(done) {
-      User
-        .findOne({ passwordResetToken: req.params.token })
-        .where('passwordResetExpires').gt(Date.now())
-        .exec((err, user) => {
-          if (err) { return next(err); }
-          if (!user) {
-            req.flash('errors', { msg: 'Password reset token is invalid or has expired.' });
-            return res.redirect('back');
-          }
-          user.password = req.body.password;
-          user.passwordResetToken = undefined;
-          user.passwordResetExpires = undefined;
-          user.save((err) => {
-            if (err) { return next(err); }
-            req.logIn(user, (err) => {
-              done(err, user);
-            });
-          });
-        });
-    },
-    function sendResetPasswordEmail(user, done) {
-      const transporter = nodemailer.createTransport({
-        service: 'SendGrid',
-        auth: {
-          user: process.env.SENDGRID_USER,
-          pass: process.env.SENDGRID_PASSWORD
+  function resetPassword() {
+    return User
+      .findOne({ passwordResetToken: req.params.token })
+      .where('passwordResetExpires').gt(Date.now())
+      .then((user) => {
+        if (!user) {
+          req.flash('errors', { msg: 'Password reset token is invalid or has expired.' });
+          return res.redirect('back');
         }
+        user.password = req.body.password;
+        user.passwordResetToken = undefined;
+        user.passwordResetExpires = undefined;
+        return user.save().then(() => new Promise((resolve, reject) => {
+          req.logIn(user, (err) => {
+            if (err) return reject(err);
+            resolve(user);
+          });
+        }));
       });
-      const mailOptions = {
-        to: user.email,
-        from: 'hackathon@starter.com',
-        subject: 'Your Hackathon Starter password has been changed',
-        text: `Hello,\n\nThis is a confirmation that the password for your account ${user.email} has just been changed.\n`
-      };
-      transporter.sendMail(mailOptions, (err) => {
-        req.flash('success', { msg: 'Success! Your password has been changed.' });
-        done(err);
+  }
+
+  function sendResetPasswordEmail(user) {
+    if (!user) return;
+    const transporter = nodemailer.createTransport({
+      service: 'SendGrid',
+      auth: {
+        user: process.env.SENDGRID_USER,
+        pass: process.env.SENDGRID_PASSWORD
+      }
+    });
+    const mailOptions = {
+      to: user.email,
+      from: 'hackathon@starter.com',
+      subject: 'Your Hackathon Starter password has been changed',
+      text: `Hello,\n\nThis is a confirmation that the password for your account ${user.email} has just been changed.\n`
+    };
+    return transporter.sendMail(mailOptions)
+      .then(() => {
+        req.flash('success', { msg: 'Success! Your password has been changed.' });    
       });
-    }
-  ], (err) => {
-    if (err) { return next(err); }
-    res.redirect('/');
-  });
+  }
+
+  resetPassword()
+    .then(sendResetPasswordEmail)
+    .then(() => { if (!res.finished) res.redirect('/'); })
+    .catch(err => next(err));
 };
 
 /**
@@ -325,51 +325,51 @@ exports.postForgot = (req, res, next) => {
     return res.redirect('/forgot');
   }
 
-  async.waterfall([
-    function createRandomToken(done) {
+  function createRandomToken() {
+    return new Promise((resolve, reject) => {
       crypto.randomBytes(16, (err, buf) => {
-        const token = buf.toString('hex');
-        done(err, token);
+        if (err) return reject(err);
+        resolve(buf.toString('hex'));
       });
-    },
-    function setRandomToken(token, done) {
-      User.findOne({ email: req.body.email }, (err, user) => {
-        if (err) { return done(err); }
-        if (!user) {
-          req.flash('errors', { msg: 'Account with that email address does not exist.' });
-          return res.redirect('/forgot');
-        }
-        user.passwordResetToken = token;
-        user.passwordResetExpires = Date.now() + 3600000; // 1 hour
-        user.save((err) => {
-          done(err, token, user);
-        });
-      });
-    },
-    function sendForgotPasswordEmail(token, user, done) {
-      const transporter = nodemailer.createTransport({
-        service: 'SendGrid',
-        auth: {
-          user: process.env.SENDGRID_USER,
-          pass: process.env.SENDGRID_PASSWORD
-        }
-      });
-      const mailOptions = {
-        to: user.email,
-        from: 'hackathon@starter.com',
-        subject: 'Reset your password on Hackathon Starter',
-        text: `You are receiving this email because you (or someone else) have requested the reset of the password for your account.\n\n
-          Please click on the following link, or paste this into your browser to complete the process:\n\n
-          http://${req.headers.host}/reset/${token}\n\n
-          If you did not request this, please ignore this email and your password will remain unchanged.\n`
-      };
-      transporter.sendMail(mailOptions, (err) => {
-        req.flash('info', { msg: `An e-mail has been sent to ${user.email} with further instructions.` });
-        done(err);
-      });
+    });
+  }
+  function setRandomToken([token, user]) {
+    if (!user) {
+      req.flash('errors', { msg: 'Account with that email address does not exist.' });
+      return res.redirect('/forgot');
     }
-  ], (err) => {
-    if (err) { return next(err); }
-    res.redirect('/forgot');
-  });
+    user.passwordResetToken = token;
+    user.passwordResetExpires = Date.now() + 3600000; // 1 hour
+    return user.save().then(() => [token, user]);
+  }
+  function sendForgotPasswordEmail([token, user]) {
+    const transporter = nodemailer.createTransport({
+      service: 'SendGrid',
+      auth: {
+        user: process.env.SENDGRID_USER,
+        pass: process.env.SENDGRID_PASSWORD
+      }
+    });
+    const mailOptions = {
+      to: user.email,
+      from: 'hackathon@starter.com',
+      subject: 'Reset your password on Hackathon Starter',
+      text: `You are receiving this email because you (or someone else) have requested the reset of the password for your account.\n\n
+        Please click on the following link, or paste this into your browser to complete the process:\n\n
+        http://${req.headers.host}/reset/${token}\n\n
+        If you did not request this, please ignore this email and your password will remain unchanged.\n`
+    };
+    return transporter.sendMail(mailOptions)
+      .then(() => {
+        req.flash('info', { msg: `An e-mail has been sent to ${user.email} with further instructions.` });
+      });
+  }
+  return Promise.all([
+    createRandomToken(),
+    User.findOne({ email: req.body.email }).exec()
+  ])
+  .then(setRandomToken)
+  .then(sendForgotPasswordEmail)
+  .then(() => res.redirect('/forgot'))
+  .catch(err => next(err));
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "bcrypt-nodejs": "^0.0.3",
+    "bluebird": "^3.4.7",
     "body-parser": "^1.15.2",
     "chalk": "^1.1.3",
     "cheerio": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "mocha --reporter spec"
   },
   "dependencies": {
-    "async": "^2.1.2",
     "bcrypt-nodejs": "^0.0.3",
     "body-parser": "^1.15.2",
     "chalk": "^1.1.3",


### PR DESCRIPTION
Remove useless `async` package from `hackathon-starter` and replace it by built-in ES6 Promises, `then()` and `all()`, which are equivalent to `async::waterfall()` and `async::parallel()` use.

Side improvements: 
* `createRandomToken()` and `User.findOne(...)` are dispatched in parallel instead of sequentially (as happened before with `waterfall()`) because there is no dependency between each other;
* Suppresses the `async` idiomatic `if (err) { return done(err); }`, because "_If an error is thrown in the executor function, the promise is rejected._" (from [developer.mozilla.org Promise](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise))
* Replaces the idiomatic `(err, results) => { if (err) { return next(err); } ... /* else block */` with `.catch(next);`
