### PR TITLE
[fix] Heroku re-deploy issue with node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "scripts": {
     "start": "node app.js",
-    "test": "mocha --reporter spec"
+    "test": "mocha --reporter spec",
+    "postinstall": "npm rebuild node-sass"
   },
   "dependencies": {
     "async": "^2.1.2",


### PR DESCRIPTION
When deploying over an already-deployed app in heroku, binaries in the `vendor` directory of module `node-sass` disappear.

This extra post-installation step will force a fetch, for the application to start properly.