### PR TITLE
Removing node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,6 @@ version: '2'
 services:
   mongo:
     image: mongo:3.4
-  node_modules:
-    build: 
-     context: .
-     dockerfile: Dockerfile_nodemodules
   web:
     build: .
     ports:


### PR DESCRIPTION
This was an example that could have been used to build / save dependencies (packages)
as separate image that would never need to be re-built. However, it is not needed or used currently. 