### PR TITLE
add gender field to facebook strategy

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -64,7 +64,7 @@ passport.use(new FacebookStrategy({
   clientID: process.env.FACEBOOK_ID,
   clientSecret: process.env.FACEBOOK_SECRET,
   callbackURL: '/auth/facebook/callback',
-  profileFields: ['name', 'email', 'link', 'locale', 'timezone'],
+  profileFields: ['name', 'email', 'link', 'locale', 'timezone', 'gender'],
   passReqToCallback: true
 }, (req, accessToken, refreshToken, profile, done) => {
   if (req.user) {


### PR DESCRIPTION
Line 108 now executes in ./config/passport.js: 
user.profile.gender = profile._json.gender;
and gender is stored in DB