### PR TITLE
Cleaning up api/index view to remove reference to BitGo

### DIFF
--- a/views/api/index.pug
+++ b/views/api/index.pug
@@ -108,12 +108,6 @@ block content
             img(src='http://i.imgur.com/bmgfsSg.png', height=40)
             |  Lob
     .col-sm-4
-      a(href='/api/bitgo', style='color: #fff')
-        .panel.panel-default(style='background-color: #142834')
-          .panel-body
-            img(src='http://i.imgur.com/v753soI.png', height=40)
-            |  BitGo
-    .col-sm-4
       a(href='/api/upload', style='color: #1565c0')
         .panel.panel-default(style='background-color: #fff')
           .panel-body


### PR DESCRIPTION
Per the changelog from July 23, 2016, BitGo was removed due to a dependency issue
with `secp256k1` and Windows. This PR removes the reference on the `API Examples`
page template, addressing issue #725.