### PR TITLE
Fixing Pug template for Last.fm API Example

### DIFF
--- a/controllers/api.js
+++ b/controllers/api.js
@@ -208,7 +208,7 @@ exports.getLastfm = (req, res, next) => {
     artistTopTracks(),
     artistTopAlbums()
   ])
-  .then(([artistInfo, artistTopAlbums, artistTopTracks]) => {
+  .then(([artistInfo, artistTopTracks, artistTopAlbums]) => {
     const artist = {
       name: artistInfo.artist.name,
       image: artistInfo.artist.image.slice(-1)[0]['#text'],

--- a/views/api/lastfm.pug
+++ b/views/api/lastfm.pug
@@ -17,7 +17,7 @@ block content
       | API Endpoints
 
   h3= artist.name
-  img.thumbnail(src='#{artist.image}')
+  img.thumbnail(src='' + artist.image)
 
   h3 Tags
   for tag in artist.tags
@@ -31,17 +31,17 @@ block content
 
   h3 Top Albums
   for album in artist.topAlbums
-    img(src='#{album.image.slice(-1)[0]["#text"]}', width=150, height=150)
-    |&nbsp;
+    img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150)
+    | &nbsp;
 
   h3 Top Tracks
   ol
     for track in artist.topTracks
       li
-        a(href='#{track.url}') #{track.name}
+        a(href='' + track.url) #{track.name}
 
   h3 Similar Artists
   ul.list-unstyled.list-inline
     for similarArtist in artist.similar
       li
-        a(href='#{similarArtist.url}') #{similarArtist.name}
+        a(href='' + similarArtist.url) #{similarArtist.name}


### PR DESCRIPTION
Many of the URLs for images and links in the API Example for Last.fm
were incorrectly referenced, due to deprecations with attribute
interpolation syntax.

In addition, the order or promise resolution had mixed up the list
of top tracks and top albums, causing the same image to be shown for
all "top albums", and the list of "top tracks" were actually album
names. This has been corrected.

Addresses issue #770.