### PR TITLE
fix - returnTo with queryParams

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,10 +106,10 @@ app.use((req, res, next) => {
       req.path !== '/signup' &&
       !req.path.match(/^\/auth/) &&
       !req.path.match(/\./)) {
-    req.session.returnTo = req.url;
+    req.session.returnTo = req.originalUrl;
   } else if (req.user &&
       req.path === '/account') {
-    req.session.returnTo = req.url;
+    req.session.returnTo = req.originalUrl;
   }
   next();
 });

--- a/app.js
+++ b/app.js
@@ -106,10 +106,10 @@ app.use((req, res, next) => {
       req.path !== '/signup' &&
       !req.path.match(/^\/auth/) &&
       !req.path.match(/\./)) {
-    req.session.returnTo = req.path;
+    req.session.returnTo = req.url;
   } else if (req.user &&
       req.path === '/account') {
-    req.session.returnTo = req.path;
+    req.session.returnTo = req.url;
   }
   next();
 });


### PR DESCRIPTION
If you want to redirect to some url with queryParams after sign up/login, app only considers path. as we set the `req.path` to `req.session.returnTo`.
This will set `req.url` so path with queryParams will be set to `req.session.returnTo`

fixes #789 