### PR TITLE
better .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,10 @@
 {
   "extends": "airbnb-base",
+  "env": {
+    "node": true,
+    "mocha": true,
+    "es6": true
+  },
   "rules": {
     "comma-dangle": 0,
     "consistent-return": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "mocha": true,
     "es6": true
   },
+  "plugins": ["chai-friendly"],
   "rules": {
     "comma-dangle": 0,
     "consistent-return": 0,


### PR DESCRIPTION
Adding env in eslint allows better code detection. For example `describe` is not underlined in red with this configuration because eslint detects that it is a unit test library.
Also, eslint always displayed `Definition for rule` chai-friendly/no-unused-expressions' was not found` because the plugin was not declared in.eslintrc.