### PR TITLE
add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - "8"
+  - "9"
+services: mongodb  
+cache:  
+  directories:
+    - "node_modules"
+sudo: false
+install:
+  - npm install
+script:
+  - npm test


### PR DESCRIPTION
Allows you to run tests on every deployment and ensure everything is working properly.

The github project must be connected to travis in order for it to perform the tests. It's free for open source projects.