### PR TITLE
remove Popular images - instagram API

### DIFF
--- a/controllers/api.js
+++ b/controllers/api.js
@@ -466,17 +466,14 @@ exports.getInstagram = async (req, res, next) => {
   try {
     const userSearchAsync = util.promisify(ig.user_search);
     const userAsync = util.promisify(ig.user);
-    const mediaPopularAsync = util.promisify(ig.media_popular);
     const userSelfMediaRecentAsync = util.promisify(ig.user_self_media_recent);
     const searchByUsername = await userSearchAsync('richellemead');
     const searchByUserId = await userAsync('175948269');
-    const popularImages = await mediaPopularAsync();
     const myRecentMedia = await userSelfMediaRecentAsync();
     return res.render('api/instagram', {
       title: 'Instagram API',
       usernames: searchByUsername,
       userById: searchByUserId,
-      popularImages,
       myRecentMedia
     });
   } catch (error) {

--- a/views/api/instagram.pug
+++ b/views/api/instagram.pug
@@ -39,25 +39,12 @@ block content
   p.lead User Search for ID
     strong  175948269
 
-
   .media
     a.pull-left(href='http://instagram.com/' + userById.username)
       img.thumbnail(src=userById.profile_picture, width='110', height='110')
     .media-body
       h4= userById.full_name
       p= userById.bio
-
-  hr
-  p.lead
-    strong Popular Images
-    |  on Instagram
-  .row
-    for image in popularImages
-      .col-xs-3
-        a.thumbnail(href=image.link)
-          img(src=image.images.standard_resolution.url, height='320px')
-
-
 
   hr
   p.lead


### PR DESCRIPTION
The popular media must be removed because it has been deprecated since 2016 and this prevents the instagram api from working. According to the [documentation](https://elfsight.com/blog/2018/02/instagram-graph-api-changes/), the rest will be depreciated in 2020 because we used `Basic` to get the information.
partially fix #822 