### PR TITLE
remove duplicate node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,6 @@
     "twit": "^2.2.9",
     "validator": "^9.4.1"
   },
-  "peerDependencies": {
-    "node-sass": "^4.7.2"
-  },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^4.19.1",


### PR DESCRIPTION
node-sass is already declared in dependencies but it is also declared in PeerDependencies. It should be removed from PeerDependencies.
Also the version in peerDependencies has not been updated.
The library is even ignored when generating the package-lock.json file because it takes into account the last version declared in the dependencies.
I tested in local, travis build and heroku. It's working fine. 
In-part from #814 