### PR TITLE
update README.md with import/export supported by node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,25 +1001,25 @@ console.log(`My cat is named ${name} and is ${age} years old.`);
 To import functions, objects or primitives exported from an external module. These are the most common types of importing.
 
 ```js
-import name from 'module-name';
+const name = require('module-name');
 ```
+
 ```js
-import * as name from 'module-name';
-```
-```js
-import { foo, bar } from 'module-name';
+const { foo, bar } = require('module-name');
 ```
 
 To export functions, objects or primitives from a given file or module.
 
 ```js
-export { myFunction };
+module.exports = { myFunction };
 ```
+
 ```js
-export const name = 'yourName';
+module.exports.name = 'yourName';
 ```
+
 ```js
-export default myFunctionOrClass
+module.exports = myFunctionOrClass;
 ```
 
 #### Spread Operator


### PR DESCRIPTION
It describes how to import and export with the es modules, but they are not supported by current versions of nodeJS. It's [experimental](https://nodejs.org/api/esm.html#esm_ecmascript_modules). You can use them with babel (or another transpilator), but it is not included in the project and will add a layer of complexity. I updated the readme with the currently supported native syntax.