### PR TITLE
Add nodeJS 10 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "8"
   - "9"
+  - "10"
 services: mongodb  
 cache:  
   directories:


### PR DESCRIPTION
It's no longer a nightly, show [blog](https://nodejs.org/en/blog/release/v10.0.0/)