### PR TITLE
remove mongoose global.Promise

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,6 @@ const app = express();
 /**
  * Connect to MongoDB.
  */
-mongoose.Promise = global.Promise;
 mongoose.connect(process.env.MONGODB_URI);
 mongoose.connection.on('error', (err) => {
   console.error(err);


### PR DESCRIPTION
`mongoose.Promise = global.Promise` is useless with mongoose > 5 because it supports natively Promise.