### PR TITLE
chore: clone last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "8"
   - "9"
   - "10"
+git:
+  checkout: 5
 services: mongodb  
 cache:  
   directories:


### PR DESCRIPTION
By default Travis clones the last 50 commits. 5 are sufficient and often faster.

See https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth