### PR TITLE
Update main.scss w/correct fontawesome filenames

### DIFF
--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -3,9 +3,9 @@
 @import "node_modules/bootstrap/scss/bootstrap";
 @import "node_modules/@ladjs/bootstrap-social/bootstrap-social.scss";
 @import "node_modules/@fortawesome/fontawesome-free/scss/fontawesome";
-@import "node_modules/@fortawesome/fontawesome-free/scss/fa-brands";
-@import "node_modules/@fortawesome/fontawesome-free/scss/fa-regular";
-@import "node_modules/@fortawesome/fontawesome-free/scss/fa-solid";
+@import "node_modules/@fortawesome/fontawesome-free/scss/brands";
+@import "node_modules/@fortawesome/fontawesome-free/scss/regular";
+@import "node_modules/@fortawesome/fontawesome-free/scss/solid";
 
 @import "themes/default/default";
 


### PR DESCRIPTION
The 5.1.0 to 5.1.1 Font-Awesome update changed the names of those files to drop the `fa-` prefix. More information at their [upgrading](https://github.com/FortAwesome/Font-Awesome/blob/master/UPGRADING.md) guide.