### PR TITLE
Update broken file references

### DIFF
--- a/public/css/themes/modern/_modern.scss
+++ b/public/css/themes/modern/_modern.scss
@@ -1,4 +1,4 @@
-@import "../../lib/bootstrap-social";
+@import "varibles";
 
 // Footer
 // -------------------------


### PR DESCRIPTION
`bootstrap-social` now lives in the node_modules directory, and is imported in main.scss. Meanwhile, this file seems to have lost importing its own variables, causing compile to fail.