### PR TITLE
Trivial doc comment format fix for Twitter auth

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -176,8 +176,9 @@ passport.use(new GitHubStrategy({
   }
 }));
 
-// Sign in with Twitter.
-
+/**
+ * Sign in with Twitter.
+ */
 passport.use(new TwitterStrategy({
   consumerKey: process.env.TWITTER_KEY,
   consumerSecret: process.env.TWITTER_SECRET,


### PR DESCRIPTION
Simple change to the doc comment for Twitter off. Noticed when I was digging through the repo.