### PR TITLE
fix #854: service error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -227,6 +227,11 @@ app.get('/auth/pinterest/callback', passport.authorize('pinterest', { failureRed
 if (process.env.NODE_ENV === 'development') {
   // only use in development
   app.use(errorHandler());
+} else {
+  app.use(function(err, req, res, next) {
+    console.error(err);
+    res.status(500).send('Server Error');
+  });
 }
 
 /**

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -227,7 +227,24 @@ exports.getLastfm = async (req, res, next) => {
       artist
     });
   } catch (err) {
-    next(err);
+    if (err.error !== undefined) {
+      console.error(err);
+      // see error code list: https://www.last.fm/api/errorcodes
+      switch(err.error) {
+        // potentially handle each code uniquely
+        case 10: // Invalid API key
+          res.render('api/lastfm', {
+            error: err
+          });
+          break;
+        default:
+          res.render('api/lastfm', {
+            error: err
+          });
+      }
+    } else {
+      next(err);
+    }
   }
 };
 

--- a/views/api/lastfm.pug
+++ b/views/api/lastfm.pug
@@ -16,36 +16,39 @@ block content
       i.fas.fa-code-branch.fa-sm
       | API Endpoints
 
-  h3= artist.name
-  if artist.image
-    img.thumbnail(src='' + artist.image)
+  if error
+    h3= error.message
+  else
+    h3= artist.name
+    if artist.image
+      img.thumbnail(src='' + artist.image)
 
-  h3 Tags
-  for tag in artist.tags
-    span.label.label-primary
-      i.fas.fa-tag.fa-sm
-      | #{tag.name}
-    |&nbsp;
+    h3 Tags
+    for tag in artist.tags
+      span.label.label-primary
+        i.fas.fa-tag.fa-sm
+        | #{tag.name}
+      |&nbsp;
 
-  h3 Biography
-  if artist.bio
-    p!= artist.bio
-  else 
-    p No biography
+    h3 Biography
+    if artist.bio
+      p!= artist.bio
+    else
+      p No biography
 
-  h3 Top Albums
-  for album in artist.topAlbums
-    img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150)
-    | &nbsp;
+    h3 Top Albums
+    for album in artist.topAlbums
+      img(src='' + album.image.slice(-1)[0]["#text"], width=150, height=150)
+      | &nbsp;
 
-  h3 Top Tracks
-  ol
-    for track in artist.topTracks
-      li
-        a(href='' + track.url) #{track.name}
+    h3 Top Tracks
+    ol
+      for track in artist.topTracks
+        li
+          a(href='' + track.url) #{track.name}
 
-  h3 Similar Artists
-  ul.list-unstyled.list-inline
-    for similarArtist in artist.similar
-      li
-        a(href='' + similarArtist.url) #{similarArtist.name}
+    h3 Similar Artists
+    ul.list-unstyled.list-inline
+      for similarArtist in artist.similar
+        li
+          a(href='' + similarArtist.url) #{similarArtist.name}


### PR DESCRIPTION
Fix for https://github.com/sahat/hackathon-starter/issues/854

- Added error handler middleware for when `NODE_ENV` is not equal to `development` that sends 500 response with generic `Server Error` message while logging the error to the server console. 
- In lastfm controller, added check for error code from the lastfm service with example of unique handling per code. Adjusted lastfm pug template to display the error message from the service when present and log to the server console. If no code present in error, pass along to generic error handler middleware.