### PR TITLE
Fix wrapping issues in the navbar and logo indentation

### DIFF
--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -52,7 +52,8 @@ textarea {
 }
 
 .navbar{
-  padding: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
   margin-bottom: 20px;
   display: block;
 }
@@ -60,13 +61,11 @@ textarea {
 .navbar-brand{
   font-size: 18px;
   float: left;
-  margin-left: 15px;
 }
 
 .navbar-toggler {
   position: relative;
   float: right;
-  margin-right: 15px;
   margin-bottom: 8px;
   margin-top: 8px;
 }
@@ -78,6 +77,40 @@ textarea {
 .dropdown-menu {
   left: initial;
   right: 0;
+}
+
+/* 
+* Solves Bootstrap 4 issue
+* https://github.com/twbs/bootstrap/issues/25654
+*/
+/* Styles in sm disposition and up */
+@media (min-width: 576px) and (max-width: 767px) {
+  /* Solves bs4 bug */
+  .navbar-expand-md > .container,
+  .navbar-expand-lg > .container,
+  .navbar-expand-xl > .container {
+    padding-left: 15px !important;
+    padding-right: 15px !important;
+  }
+}
+
+/* Styles in md disposition and up */
+@media (min-width: 768px) and (max-width: 991px) {
+  /* Solves bs4 bug */
+  .navbar-expand-lg > .container,
+  .navbar-expand-xl > .container {
+    padding-left: 15px !important;
+    padding-right: 15px !important;
+  }
+}
+
+/* Styles in lg disposition and up */
+@media (min-width: 992px) and (max-width: 1199px) {
+  /* Solves bs4 bug */
+  .navbar-expand-xl > .container {
+    padding-left: 15px !important;
+    padding-right: 15px !important;
+  }
 }
 
 // Alerts

--- a/views/partials/header.pug
+++ b/views/partials/header.pug
@@ -1,4 +1,4 @@
-.navbar.navbar-light.fixed-top.navbar-expand-md
+.navbar.navbar-light.fixed-top.navbar-expand-lg
   .container
     a.navbar-brand(href='/')
       i.fas.fa-cube


### PR DESCRIPTION
It collapses the navbar one breakpoint up (md > lg) fixing the alignment of the nav links, but to make this work properly, a Bootstrap 4 bug (https://github.com/twbs/bootstrap/issues/25654) needed to be addressed and this also solved the logo indentation.

As these are visually breaking issues in the current build, I tought it could be pulled separately from the other issues on #853 

Thanks!