### PR TITLE
Re-order JS includes: Popper ahead of Bootstrap

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -20,8 +20,8 @@ html
     include partials/footer
 
     script(src='/js/lib/jquery.min.js')
-    script(src='/js/lib/bootstrap.min.js')
     script(src='/js/lib/popper.min.js')
+    script(src='/js/lib/bootstrap.min.js')
     script(src='/js/main.js')
 
     // Google Analytics: change UA-XXXXX-X to be your site's ID


### PR DESCRIPTION
Per the [bootstrap documentation](https://getbootstrap.com/docs/4.0/components/popovers/):

> You must include popper.min.js before bootstrap.js or use bootstrap.bundle.min.js / bootstrap.bundle.js which contains Popper.js in order for popovers to work!

When popper is included _after_ bootstrap, the result is an error in the console when popper is initialized:

```
Uncaught TypeError: Bootstrap tooltips require Popper.js (https://popper.js.org)
    at i (tooltip.js:117)
    at new i (popover.js:11)
    at HTMLButtonElement.<anonymous> (popover.js:158)
    at Function.each (jquery.min.js:2)
    at w.fn.init.each (jquery.min.js:2)
    at w.fn.init.i._jQueryInterface [as popover] (popover.js:149)
    at HTMLDocument.<anonymous> (main.js:6)
    at l (jquery.min.js:2)
    at c (jquery.min.js:2)
```