### PR TITLE
Refactored to use axios

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -1,5 +1,5 @@
 const passport = require('passport');
-const request = require('request');
+const axios = require('axios');
 const { Strategy: InstagramStrategy } = require('passport-instagram');
 const { Strategy: LocalStrategy } = require('passport-local');
 const { Strategy: FacebookStrategy } = require('passport-facebook');
@@ -528,42 +528,38 @@ passport.use(new OpenIDStrategy({
           if (err) { return done(err); }
           user.steam = steamId;
           user.tokens.push({ kind: 'steam', accessToken: steamId });
-          request(profileURL, (error, response, body) => {
-            if (!error && response.statusCode === 200) {
-              const data = JSON.parse(body);
-              const profile = data.response.players[0];
+          axios.get(profileURL)
+            .then((res) => {
+              const profile = res.data.response.players[0];
               user.profile.name = user.profile.name || profile.personaname;
               user.profile.picture = user.profile.picture || profile.avatarmedium;
               user.save((err) => {
                 done(err, user);
               });
-            } else {
+            })
+            .catch((err) => {
               user.save((err) => { done(err, user); });
-              done(error, null);
-            }
-          });
+              done(err, null);
+            });
         });
       }
     });
   } else {
-    request(profileURL, (error, response, body) => {
-      if (!error && response.statusCode === 200) {
-        const data = JSON.parse(body);
+    axios.get(profileURL)
+      .then(({ data }) => {
         const profile = data.response.players[0];
-
         const user = new User();
         user.steam = steamId;
         user.email = `${steamId}@steam.com`; // steam does not disclose emails, prevent duplicate keys
         user.tokens.push({ kind: 'steam', accessToken: steamId });
-        user.profile.name = profile.personaname;
+        user.profile.name = profile.personname;
         user.profile.picture = profile.avatarmedium;
         user.save((err) => {
           done(err, user);
         });
-      } else {
-        done(error, null);
-      }
-    });
+      }).catch((err) => {
+        done(err, null);
+      });
   }
 }));
 

--- a/config/passport.js
+++ b/config/passport.js
@@ -552,7 +552,7 @@ passport.use(new OpenIDStrategy({
         user.steam = steamId;
         user.email = `${steamId}@steam.com`; // steam does not disclose emails, prevent duplicate keys
         user.tokens.push({ kind: 'steam', accessToken: steamId });
-        user.profile.name = profile.personname;
+        user.profile.name = profile.personaname;
         user.profile.picture = profile.avatarmedium;
         user.save((err) => {
           done(err, user);

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -145,20 +145,21 @@ exports.getAviary = (req, res) => {
  * New York Times API example.
  */
 exports.getNewYorkTimes = (req, res, next) => {
-  const query = {
-    'list-name': 'young-adult',
-    'api-key': process.env.NYT_KEY
-  };
-  request.get({ url: 'http://api.nytimes.com/svc/books/v2/lists', qs: query }, (err, request, body) => {
-    if (err) { return next(err); }
-    if (request.statusCode >= 400) {
-      return next(new Error(`New York Times API - ${body}`));
-    }
-    const books = JSON.parse(body).results;
+  const apiKey = process.env.NYT_KEY
+  const url = new URL('http://api.nytimes.com/svc/books/v2/lists');
+  url.searchParams.append('list-name', 'young-adult');
+  url.searchParams.append('api-key', 'JItWGN9QpZ9KPV2OZrX0W88P7NFuhKL0');
+  axios.get(url.toString())
+  .then(axiosRes => {
+    const books = axiosRes.data.results;
     res.render('api/nyt', {
       title: 'New York Times API',
       books
     });
+  })
+  .catch(err => {
+    const message = JSON.stringify(err.response.data.fault)
+    return next(new Error(`New York Times API - ${err.response.status} ${err.response.statusText} ${message}`))
   });
 };
 

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -639,17 +639,6 @@ exports.postFileUpload = (req, res) => {
  * GET /api/pinterest
  * Pinterest API example.
  */
-// exports.getPinterest = (req, res, next) => {
-//   const token = req.user.tokens.find(token => token.kind === 'pinterest');
-//   request.get({ url: 'https://api.pinterest.com/v1/me/boards/', qs: { access_token: token.accessToken }, json: true }, (err, request, body) => {
-//     if (err) { return next(err); }
-//     console.log(body.data)
-//     res.render('api/pinterest', {
-//       title: 'Pinterest API',
-//       boards: body.data
-//     });
-//   });
-// };
 exports.getPinterest = (req, res, next) => {
   const token = req.user.tokens.find(token => token.kind === 'pinterest');
   axios.get(`https://api.pinterest.com/v1/me/boards?access_token=${token.accessToken}`)
@@ -667,36 +656,6 @@ exports.getPinterest = (req, res, next) => {
  * POST /api/pinterest
  * Create a pin.
  */
-// exports.postPinterest = (req, res, next) => {
-//   req.assert('board', 'Board is required.').notEmpty();
-//   req.assert('note', 'Note cannot be blank.').notEmpty();
-//   req.assert('image_url', 'Image URL cannot be blank.').notEmpty();
-
-//   const errors = req.validationErrors();
-
-//   if (errors) {
-//     req.flash('errors', errors);
-//     return res.redirect('/api/pinterest');
-//   }
-
-//   const token = req.user.tokens.find(token => token.kind === 'pinterest');
-//   const formData = {
-//     board: req.body.board,
-//     note: req.body.note,
-//     link: req.body.link,
-//     image_url: req.body.image_url
-//   };
-
-//   request.post('https://api.pinterest.com/v1/pins/', { qs: { access_token: token.accessToken }, form: formData }, (err, request, body) => {
-//     if (err) { return next(err); }
-//     if (request.statusCode !== 201) {
-//       req.flash('errors', { msg: JSON.parse(body).message });
-//       return res.redirect('/api/pinterest');
-//     }
-//     req.flash('success', { msg: 'Pin created' });
-//     res.redirect('/api/pinterest');
-//   });
-// };
 exports.postPinterest = (req, res, next) => {
   req.assert('board', 'Board is required.').notEmpty();
   req.assert('note', 'Note cannot be blank').notEmpty();
@@ -717,7 +676,7 @@ exports.postPinterest = (req, res, next) => {
     image_url: req.body.image_url
   };
 
-  axios.post(`https://api.pinterest.com/v1/me/boards/?access_token=${token.accessToken}`, formData)
+  axios.post(`https://api.pinterest.com/v1/pins/?access_token=${token.accessToken}`, formData)
   .then(response => {
     req.flash('success', { msg: 'Pin created'});
     res.redirect('/api/pinterest');

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -306,25 +306,31 @@ exports.getSteam = async (req, res, next) => {
   const steamId = req.user.steam;
   const params = { l: 'english', steamid: steamId, key: process.env.STEAM_KEY };
   const getAsync = promisify(request.get);
-
-  // get the list of the recently played games, pick the most recent one and get its achievements
-  const getPlayerAchievements = () =>
-    getAsync({ url: 'http://api.steampowered.com/IPlayerService/GetRecentlyPlayedGames/v0001/', qs: params, json: true })
-      .then(({ request, body }) => {
-        if (request.statusCode === 401) {
-          throw new Error('Invalid Steam API Key');
-        }
-        if (body.response.total_count > 0) {
-          params.appid = body.response.games[0].appid;
-          return getAsync({ url: 'http://api.steampowered.com/ISteamUserStats/GetPlayerAchievements/v0001/', qs: params, json: true })
-            .then(({ request, body }) => {
-              if (request.statusCode === 401) {
-                throw new Error('Invalid Steam API Key');
-              }
-              return body;
-            });
-        }
-      });
+  
+  const makeURL = (domainAndPath, queryParams) => {
+    const url = new URL(domainAndPath)
+    const encodedQuery = new URLSearchParams(queryParams)
+    url.search = encodedQuery.toString()
+    return url.toString()
+  }
+    // get the list of the recently played games, pick the most recent one and get its achievements
+  const getPlayerAchievements = () => {
+    const recentGamesURL = makeURL('http://api.steampowered.com/IPlayerService/GetRecentlyPlayedGames/v0001/', params)
+    return axios.get(recentGamesURL)
+    .then(({ data }) => {
+      if (data.response.total_count > 0) {
+        params.appid = data.response.games[0].appid;
+        const achievementsURL = makeURL('http://api.steampowered.com/ISteamUserStats/GetPlayerAchievements/v0001/', params);
+        return axios.get(achievementsURL)
+        .then(({ data }) => {
+          return data.playerstats
+        })
+      };
+    })
+    .catch(error => {
+      throw new Error('Missing or Invalid Steam API Key')
+    });
+  };
   const getPlayerSummaries = () => {
     params.steamids = steamId;
     return getAsync({ url: 'http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/', qs: params, json: true })
@@ -347,13 +353,13 @@ exports.getSteam = async (req, res, next) => {
       });
   };
   try {
-    const { playerstats } = await getPlayerAchievements();
+    const playerstats = await getPlayerAchievements();
     const playerSummaries = await getPlayerSummaries();
     const ownedGames = await getOwnedGames();
     res.render('api/steam', {
       title: 'Steam Web API',
       ownedGames: ownedGames.response,
-      playerAchievemments: playerstats.success ? playerstats : null,
+      playerAchievements: playerstats.success ? playerstats : null,
       playerSummary: playerSummaries.response.players[0]
     });
   } catch (err) {

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -326,7 +326,11 @@ exports.getSteam = async (req, res, next) => {
         params.appid = data.response.games[0].appid;
         const achievementsURL = makeURL('http://api.steampowered.com/ISteamUserStats/GetPlayerAchievements/v0001/', params);
         return axios.get(achievementsURL)
-          .then(({ data }) => data);
+          .then(({ data }) => {
+            if (!data.playerstats.success) {
+              return { playerstats: null }
+            }
+          });
       });
   };
   const getPlayerSummaries = () => {
@@ -658,7 +662,7 @@ exports.getPinterest = (req, res, next) => {
  */
 exports.postPinterest = (req, res, next) => {
   req.assert('board', 'Board is required.').notEmpty();
-  req.assert('note', 'Note cannot be blank').notEmpty();
+  req.assert('note', 'Note cannot be blank.').notEmpty();
   req.assert('image_url', 'Image URL cannot be blank.').notEmpty();
 
   const errors = req.validationErrors();

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -98,10 +98,10 @@ exports.getFacebook = (req, res, next) => {
  * Web scraping example using Cheerio library.
  */
 exports.getScraping = (req, res, next) => {
-  request.get('https://news.ycombinator.com/', (err, request, body) => {
-    if (err) { return next(err); }
-    const $ = cheerio.load(body);
-    const links = [];
+  axios.get('https://news.ycombinator.com/')
+  .then(axiosRes => {
+    const $ = cheerio.load(axiosRes.data);
+    const links = []
     $('.title a[href^="http"], a[href^="https"]').slice(1).each((index, element) => {
       links.push($(element));
     });
@@ -109,7 +109,8 @@ exports.getScraping = (req, res, next) => {
       title: 'Web Scraping',
       links
     });
-  });
+  })
+  .catch(err => next(err));
 };
 
 /**

--- a/views/api/steam.pug
+++ b/views/api/steam.pug
@@ -30,10 +30,10 @@ block content
         else
           strong.text-danger  Offline
 
-  if playerAchievemments
-    h3 #{playerAchievemments.gameName} Achievements
+  if playerAchievements
+    h3 #{playerAchievements.gameName} Achievements
     ul.lead.list-unstyled
-      for achievement in playerAchievemments.achievements
+      for achievement in playerAchievements.achievements
         if achievement.achieved
           li.text-success= achievement.name
   else


### PR DESCRIPTION
#### This pr is in reference to #952 - use of Axios instead of request

Updates the routes for:
- [x] New York Times
- [x] Web scraping
- [x] Pinterest

I tried to keep the format of each route as consistent as I could. Each route has been manually tested with corresponding api keys.

Any feedback is welcome!

#### Update:
Done! 
Request is no longer a dependency.

Passport.js:
- [x] steam auth