### PR TITLE
Fix for Google Oauth2 profile picture

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -309,7 +309,7 @@ passport.use(new GoogleStrategy({
           user.tokens.push({ kind: 'google', accessToken });
           user.profile.name = user.profile.name || profile.displayName;
           user.profile.gender = user.profile.gender || profile._json.gender;
-          user.profile.picture = user.profile.picture || profile._json.image.url;
+          user.profile.picture = user.profile.picture || profile._json.picture;
           user.save((err) => {
             req.flash('info', { msg: 'Google account has been linked.' });
             done(err, user);
@@ -335,7 +335,7 @@ passport.use(new GoogleStrategy({
           user.tokens.push({ kind: 'google', accessToken });
           user.profile.name = profile.displayName;
           user.profile.gender = profile._json.gender;
-          user.profile.picture = profile._json.image.url;
+          user.profile.picture = profile._json.picture;
           user.save((err) => {
             done(err, user);
           });


### PR DESCRIPTION
Seems Google API changed its response and it is not possible to register a new user with google anymore. This small changes fixes the way to user's profile picture from the JSON data.