### PR TITLE
Use app.host variable in app.listen() call

### DIFF
--- a/app.js
+++ b/app.js
@@ -253,8 +253,8 @@ if (process.env.NODE_ENV === 'development') {
 /**
  * Start Express server.
  */
-app.listen(app.get('port'), () => {
-  console.log('%s App is running at http://localhost:%d in %s mode', chalk.green('✓'), app.get('port'), app.get('env'));
+app.listen(app.get('port'), app.get('host'), () => {
+  console.log('%s App is running at http://%s:%d in %s mode', chalk.green('✓'), app.get('host'), app.get('port'), app.get('env'));
   console.log('  Press CTRL-C to stop\n');
 });
 


### PR DESCRIPTION
I'm assuming this was intended. Or maybe you always want to listen to `0.0.0.0`, but still then it would be nice to log the value of `app.get('host')` when the server starts, IMO.