### PR TITLE
Fix navbar rendering issues with theme support

### DIFF
--- a/public/css/themes/default/_default.scss
+++ b/public/css/themes/default/_default.scss
@@ -78,10 +78,6 @@
     background: rgb(221, 221, 221);
   }
 
-  // backward default theme compatibility
-  // for background color to achieve correctly
-  // themed navigation bar in Bootswatch in other
-  // style themes
   &.bg-light {
     background-color: #ffffff !important;
   }

--- a/public/css/themes/default/_default.scss
+++ b/public/css/themes/default/_default.scss
@@ -77,6 +77,14 @@
   .navbar-toggler:hover {
     background: rgb(221, 221, 221);
   }
+
+  // backward default theme compatibility
+  // for background color to achieve correctly
+  // themed navigation bar in Bootswatch in other
+  // style themes
+  &.bg-light {
+    background-color: #ffffff !important;
+  }
 }
 
 .navbar-toggler-icon {

--- a/views/partials/header.pug
+++ b/views/partials/header.pug
@@ -1,4 +1,4 @@
-.navbar.navbar-light.fixed-top.navbar-expand-lg
+.navbar.navbar-light.fixed-top.navbar-expand-lg.bg-light
   .container
     a.navbar-brand(href='/')
       i.fas.fa-cube


### PR DESCRIPTION
This corrects rendering the navbar using convention used by Bootswatch
and BS4, which usually either defaults to default styles for navbar or
uses combination of the navbar custom style and navbar custom baground
color (bg-*). IF `bg-*` is not present, this could lead to the
transparent background color for navbar when expanded.

The change contains a backward compatiblity fix for default theme, which
was done by not overriding `bg-*` value in navbars, but by using custom
background color as it was used before some changes in BS4. So by
default theme will use backward compatible override for background
color, not one that comes with the BS4 for 'bg-light' class.

The problems are discussed in comments here:
https://github.com/sahat/hackathon-starter/issues/853#issuecomment-475932533
https://github.com/sahat/hackathon-starter/issues/853#issuecomment-475934766

Thanks!

<img width="635" alt="Screenshot 2019-11-03 at 20 06 55" src="https://user-images.githubusercontent.com/14539/68090789-4c3b5c00-fe78-11e9-86ea-24b831234e72.png">
<img width="635" alt="Screenshot 2019-11-03 at 20 05 53" src="https://user-images.githubusercontent.com/14539/68090790-4c3b5c00-fe78-11e9-86cc-c08e14e3a13d.png">
