### PR TITLE
Use HTML5 native client form validation. Closes #1013

### DIFF
--- a/views/account/profile.pug
+++ b/views/account/profile.pug
@@ -9,7 +9,7 @@ block content
     .form-group.row
       label.col-md-3.col-form-label.font-weight-bold.text-right(for='email') Email
       .col-md-7
-        input.form-control(type='email', name='email', id='email', value=user.email, autocomplete='email')
+        input.form-control(type='email', name='email', id='email', value=user.email, autocomplete='email', required)
       .offset-sm-3.col-md-7.pl-3
         if user.emailVerified
           .text-success.font-italic
@@ -62,11 +62,11 @@ block content
     .form-group.row
       label.col-md-3.col-form-label.font-weight-bold.text-right(for='password') New Password
       .col-md-7
-        input.form-control(type='password', name='password', id='password', autocomplete='new-password')
+        input.form-control(type='password', name='password', id='password', autocomplete='new-password', minlength='8', required)
     .form-group.row
       label.col-md-3.col-form-label.font-weight-bold.text-right(for='confirmPassword') Confirm Password
       .col-md-7
-        input.form-control(type='password', name='confirmPassword', id='confirmPassword', autocomplete='new-password')
+        input.form-control(type='password', name='confirmPassword', id='confirmPassword', autocomplete='new-password', minlength='8', required)
     .form-group
       .offset-sm-3.col-md-7.pl-2
         button.btn.btn-primary(type='submit')

--- a/views/account/reset.pug
+++ b/views/account/reset.pug
@@ -8,11 +8,11 @@ block content
     .form-group.row
       label.col-md-3.col-form-label.font-weight-bold.text-right(for='password') New Password
       .col-md-7
-        input.form-control(type='password', name='password', id='password', placeholder='New password', autofocus, autocomplete='new-password', required)
+        input.form-control(type='password', name='password', id='password', placeholder='New password', autofocus, autocomplete='new-password', minlength='8', required)
     .form-group.row
       label.col-md-3.col-form-label.font-weight-bold.text-right(for='confirm') Confirm Password
       .col-md-7
-        input.form-control(type='password', name='confirm', id='confirm', placeholder='Confirm password', autocomplete='new-password', required)
+        input.form-control(type='password', name='confirm', id='confirm', placeholder='Confirm password', autocomplete='new-password', minlength='8', required)
     .form-group.offset-sm-3.col-md-7.pl-2
       button.btn.btn-primary.btn-reset(type='submit')
         i.far.fa-keyboard.fa-sm

--- a/views/account/signup.pug
+++ b/views/account/signup.pug
@@ -12,11 +12,11 @@ block content
     .form-group.row
       label.col-md-3.col-form-label.font-weight-bold.text-right(for='password') Password
       .col-md-7
-        input.form-control(type='password', name='password', id='password', placeholder='Password', autocomplete='new-password', required)
+        input.form-control(type='password', name='password', id='password', placeholder='Password', autocomplete='new-password', minlength='8', required)
     .form-group.row
       label.col-md-3.col-form-label.font-weight-bold.text-right(for='confirmPassword') Confirm Password
       .col-md-7
-        input.form-control(type='password', name='confirmPassword', id='confirmPassword', placeholder='Confirm Password', autocomplete='new-password', required)
+        input.form-control(type='password', name='confirmPassword', id='confirmPassword', placeholder='Confirm Password', autocomplete='new-password', minlength='8', required)
     .form-group.offset-sm-3.col-md-7.pl-2
       button.btn.btn-success(type='submit')
         i.fas.fa-user-plus.fa-sm

--- a/views/contact.pug
+++ b/views/contact.pug
@@ -10,15 +10,15 @@ block content
       .form-group.row
         label(class='col-md-2 col-form-label font-weight-bold', for='name') Name
         .col-md-8
-          input.form-control(type='text', name='name', id='name', autocomplete='name', autofocus=true)
+          input.form-control(type='text', name='name', id='name', autocomplete='name', autofocus, required)
       .form-group.row
         label(class='col-md-2 col-form-label font-weight-bold', for='email') Email
         .col-md-8
-          input.form-control(type='text', name='email', id='email', autocomplete='email')
+          input.form-control(type='email', name='email', id='email', autocomplete='email', required)
     .form-group.row
       label(class='col-md-2 col-form-label font-weight-bold', for='message') Please describe the issue or your suggestion
       .col-md-8
-        textarea.form-control(name='message', id='message', rows='7', autofocus=(!unknownUser).toString())
+        textarea.form-control(name='message', id='message', rows='7', autofocus=(!unknownUser).toString(), required)
     .form-group
       .offset-md-2.col-md-8.p-1
         button.btn.btn-primary(type='submit')


### PR DESCRIPTION
Wherever that is possible to sync client HTML5 form validation with the
rules used on the server to validate user input, use type, min length
and required when applicable:

- add type=email, whenever email input is expected
- add minlength attribute, whenever input lenght is checked
- add required, whenever input is checked against empty values.

Thanks!