### PR TITLE
Rework .btn-raised as BS custom button style. Fixes #1016

### DIFF
--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -79,6 +79,21 @@ textarea {
   right: 0;
 }
 
+// button raised definition
+// this button uses gradient for the background
+$btn-raised-color: rgb(51, 51, 51);
+$btn-raised-background: #f8f8f8;
+$btn-raised-border: rgb(204, 204, 204);
+$enable-gradients: true;
+
+.btn-raised {
+  @include button-variant(
+    $btn-raised-background,
+    $btn-raised-border,
+    $btn-raised-color
+  )
+}
+
 /*
 * Solves Bootstrap 4 issue
 * https://github.com/twbs/bootstrap/issues/25654
@@ -156,19 +171,4 @@ textarea {
   &:hover, &:active {
     background-color: #f1ef00;
   }
-}
-
-// button raised definition
-// this button uses gradient for the background
-$btn-raised-color: rgb(51, 51, 51);
-$btn-raised-background: #f8f8f8;
-$btn-raised-border: rgb(204, 204, 204);
-$enable-gradients: true;
-
-.btn-raised {
-  @include button-variant(
-    $btn-raised-background,
-    $btn-raised-border,
-    $btn-raised-color
-  )
 }

--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -157,3 +157,18 @@ textarea {
     background-color: #f1ef00;
   }
 }
+
+// button raised definition
+// this button uses gradient for the background
+$btn-raised-color: rgb(51, 51, 51);
+$btn-raised-background: #f8f8f8;
+$btn-raised-border: rgb(204, 204, 204);
+$enable-gradients: true;
+
+.btn-raised {
+  @include button-variant(
+    $btn-raised-background,
+    $btn-raised-border,
+    $btn-raised-color
+  )
+}

--- a/public/css/themes/default/_default.scss
+++ b/public/css/themes/default/_default.scss
@@ -16,12 +16,6 @@
   box-shadow: none;
 }
 
-.btn-raised, .btn-raised:focus, .btn-raised:active, .btn-raised:hover {
-  color: rgb(51, 51, 51);
-  background-image: linear-gradient(to bottom, #ffffff 60%, #f8f8f8 100%);
-  border-color: rgb(204, 204, 204);
-}
-
 // Forms
 // -------------------------
 


### PR DESCRIPTION
This is the proposed way of fix issue with the custom `btn-raised` button variant 
being specific only to  the `default` theme in the project, which impacts rendering of the
content if other theme is being used.

This moves definition of the `.btn-raised` out of the `default` theme
definition into the main style project file, so it can be part of the
project style no matter what theme is applied to the project.
If users want to opt-out from that style, it's as easy now as replacing
the `btn-raised` type with e.g built-in one, like `btn-primary`.
The default state of the button tries to retain as much as possible
representation of the button under the default theme definition, while
also providing BS based variants for other states of the button like
active, focused, disabled, etc.

Rendering before:

<img width="637" alt="Screenshot 2019-11-04 at 20 56 44" src="https://user-images.githubusercontent.com/14539/68153923-bde1db80-ff46-11e9-8046-6b362f261996.png">

Rendering after:
<img width="592" alt="Screenshot 2019-11-04 at 21 08 59" src="https://user-images.githubusercontent.com/14539/68154237-6001c380-ff47-11e9-8896-77e75c16472a.png">



Thanks!