### PR TITLE
Update GitHub API Keys instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The same goes for other providers.
 
 - Go to <a href="https://github.com/settings/profile" target="_blank">Account Settings</a>
 - Select **Developer settings** from the sidebar
-- Then inside click on **Register new application**
+- Then click on **OAuth Apps** and then on **Register new application**
 - Enter *Application Name* and *Homepage URL*
 - For *Authorization Callback URL*: http://localhost:8080/auth/github/callback
 - Click **Register application**


### PR DESCRIPTION
Hi,
I added `Click on "OAuth Apps"` in the GitHub API keys instruction, because otherwise, we may click on the "Register new application" under the `Github Apps` nav (the default one), which will be embarrassing ^^