### PR TITLE
Upgrade passport strategy for twitch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5498,9 +5498,9 @@
       "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
     },
     "passport-twitch-new": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/passport-twitch-new/-/passport-twitch-new-0.0.1.tgz",
-      "integrity": "sha512-GYdv/JI4Lp+G7FYNJlpKntHmjafwZCl0Rrp44pCDWjn6Ml0eaC6i4Fp1QU3m2XlpvVslLtZWeNtgMmfgPmbEew==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/passport-twitch-new/-/passport-twitch-new-0.0.2.tgz",
+      "integrity": "sha512-cNBwq4yUGO/H6NI42OAJTAXIOuQhFkfce7YG0h3HtUr5JIRwXXsHQLUhtiyO3fO+Dp1NItOjtUc384mkrpcQwQ==",
       "requires": {
         "jsonwebtoken": "^8.2.1",
         "passport-oauth2": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "passport-oauth2-refresh": "^2.0.0",
     "passport-openid": "^0.4.0",
     "passport-snapchat": "^1.0.0",
-    "passport-twitch-new": "^0.0.1",
+    "passport-twitch-new": "0.0.2",
     "passport-twitter": "^1.0.4",
     "paypal-rest-sdk": "^1.8.1",
     "popper.js": "^1.16.1",


### PR DESCRIPTION
This fixes #1078 

Upgrading the passport strategy for twitch. There were some updates on headers being passed in the request for userprofile.