### PR TITLE
Use API keys for SendGrid emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ SESSION_SECRET=Your Session Secret goes here
 MAILGUN_USER=postmaster@sandbox697fcddc09814c6b83718b9fd5d4e5dc.mailgun.org
 MAILGUN_PASSWORD=29eldds1uri6
 
+# Use either API key, or user and password
+SENDGRID_API_KEY=SG.FTVlhySoS0W5JJPgDvS3srw.0uJs1kyg5FAQkZldpVnc8k1DTzpiWDkYccjGrkvdSvU
 SENDGRID_USER=hslogin
 SENDGRID_PASSWORD=hspassword00
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ The same goes for other providers.
 
 - Go to <a href="https://sendgrid.com/user/signup" target="_blank">https://sendgrid.com/user/signup</a>
 - Sign up and **confirm** your account via the *activation email*
-- Then enter your SendGrid *Username* and *Password* into `.env` file
+- Then enter your SendGrid *Username* and *Password* into `.env` file for SMTP emails, or enter your API key to send emails using the SendGrid API.
 
 <hr>
 

--- a/controllers/contact.js
+++ b/controllers/contact.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const validator = require('validator');
 const nodemailer = require('nodemailer');
+const nodemailerSendgrid = require('nodemailer-sendgrid');
 
 /**
  * GET /contact
@@ -57,13 +58,22 @@ exports.postContact = async (req, res) => {
       fromEmail = req.user.email;
     }
 
-    let transporter = nodemailer.createTransport({
-      service: 'SendGrid',
-      auth: {
-        user: process.env.SENDGRID_USER,
-        pass: process.env.SENDGRID_PASSWORD
+    let transportConfig
+    if (process.env.SENDGRID_API_KEY) {
+      transportConfig = nodemailerSendgrid({
+        apiKey: process.env.SENDGRID_API_KEY
+      })
+    } else {
+      transportConfig = {
+        service: 'SendGrid',
+        auth: {
+          user: process.env.SENDGRID_USER,
+          pass: process.env.SENDGRID_PASSWORD
+        }
       }
-    });
+    }
+
+    let transporter = nodemailer.createTransport(transportConfig);
     const mailOptions = {
       to: process.env.SITE_CONTACT_EMAIL,
       from: `${fromName} <${fromEmail}>`,
@@ -79,16 +89,10 @@ exports.postContact = async (req, res) => {
       .catch((err) => {
         if (err.message === 'self signed certificate in certificate chain') {
           console.log('WARNING: Self signed certificate in certificate chain. Retrying with the self signed certificate. Use a valid certificate if in production.');
-          transporter = nodemailer.createTransport({
-            service: 'SendGrid',
-            auth: {
-              user: process.env.SENDGRID_USER,
-              pass: process.env.SENDGRID_PASSWORD
-            },
-            tls: {
-              rejectUnauthorized: false
-            }
-          });
+        
+          transportConfig.tls = transportConfig.tls || {}
+          transportConfig.tls.rejectUnauthorized = false
+          transporter = nodemailer.createTransport(transportConfig);
           return transporter.sendMail(mailOptions);
         }
         console.log('ERROR: Could not send contact email after security downgrade.\n', err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -566,6 +566,80 @@
         "@types/node": ">= 8"
       }
     },
+    "@sendgrid/client": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-6.5.5.tgz",
+      "integrity": "sha512-Nbfgo94gbWSL8PIgJfuHoifyOJJepvV8NQkkglctAEfb1hyozKhrzE6v1kPG/z4j0RodaTtXD5LJj/t0q/VhLA==",
+      "requires": {
+        "@sendgrid/helpers": "^6.5.5",
+        "@types/request": "^2.48.4",
+        "request": "^2.88.0"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-6.5.5.tgz",
+      "integrity": "sha512-uRFEanalfss5hDsuzVXZ1wm7i7eEXHh1py80piOXjobiQ+MxmtR19EU+gDSXZ+uMcEehBGhxnb7QDNN0q65qig==",
+      "requires": {
+        "chalk": "^2.0.1",
+        "deepmerge": "^4.2.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-6.5.5.tgz",
+      "integrity": "sha512-DSu8oTPI0BJFH60jMOG9gM+oeNMoRALFmdAYg2PIXpL+Zbxd7L2GzQZtmf1jLy/8UBImkbB3D74TjiOBiLRK1w==",
+      "requires": {
+        "@sendgrid/client": "^6.5.5",
+        "@sendgrid/helpers": "^6.5.5"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -619,6 +693,11 @@
         "@types/connect": "*",
         "@types/node": "*"
       }
+    },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -680,6 +759,29 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
+    "@types/request": {
+      "version": "2.48.5",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.5",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
@@ -688,6 +790,11 @@
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -1709,6 +1816,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-require-extensions": {
       "version": "3.0.0",
@@ -4841,6 +4953,14 @@
       "version": "6.4.13",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.13.tgz",
       "integrity": "sha512-XmtiiKza2Cqtr+ZRMchMZn9s2nmwQDeakbf+yL0ODsIXOv58UZgk/MKPOkDKqY+mvxHs87PrJK7Nf/tcpKHqYQ=="
+    },
+    "nodemailer-sendgrid": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer-sendgrid/-/nodemailer-sendgrid-1.0.3.tgz",
+      "integrity": "sha512-To/veO2M4evjtv1XrY7BUgE+LDypgs/FBx4wOHb2UNTpvZhiARtvMaBI0685Yxkho0lIPJc4jS0cUE7v+XGNgg==",
+      "requires": {
+        "@sendgrid/mail": "^6.2.1"
+      }
     },
     "nopt": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "node-sass": "^4.14.1",
     "node-sass-middleware": "^0.11.0",
     "nodemailer": "^6.4.13",
+    "nodemailer-sendgrid": "^1.0.3",
     "passport": "^0.4.1",
     "passport-facebook": "^3.0.0",
     "passport-github2": "^0.1.12",


### PR DESCRIPTION
Fix for #1110 

Maintains backwards compatibility with username and password auth.

I made this change on my local project before looking into what the community was doing. Looks like there might already be people working on it. Also there's #1105 that would conflict with this PR. If you're desperate to get in a fix before Nov 18 then merging this might be an OK option, otherwise this should probably just be used as a reference for the actual fix.