### PR TITLE
Map docker mongo port with machine (hacktoberfest feature)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   mongo:
     image: mongo:3.6
+    ports:
+     - "27017:27017"
   web:
     build: .
     ports:


### PR DESCRIPTION
I have mapped the docker mongo port with the machine so that we can easily use docker mongo independently with the app