### PR TITLE
Fix Apple Icon width in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Prerequisites
 - [MongoDB](https://www.mongodb.com/download-center/community)
 - [Node.js 10+](http://nodejs.org)
 - Command Line Tools
- - <img src="http://deluge-torrent.org/images/apple-logo.gif" height="17">&nbsp;**Mac OS X:** [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) (or **OS X 10.9+**: `xcode-select --install`)
+ - <img src="http://deluge-torrent.org/images/apple-logo.gif" height="17" width="17">&nbsp;**Mac OS X:** [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) (or **OS X 10.9+**: `xcode-select --install`)
  - <img src="http://dc942d419843af05523b-ff74ae13537a01be6cfec5927837dcfe.r14.cf1.rackcdn.com/wp-content/uploads/windows-8-50x50.jpg" height="17">&nbsp;**Windows:** [Visual Studio](https://www.visualstudio.com/products/visual-studio-community-vs) OR [Visual Studio Code](https://code.visualstudio.com) + [Windows Subsystem for Linux - Ubuntu](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
  - <img src="https://lh5.googleusercontent.com/-2YS1ceHWyys/AAAAAAAAAAI/AAAAAAAAAAc/0LCb_tsTvmU/s46-c-k/photo.jpg" height="17">&nbsp;**Ubuntu** / <img src="https://upload.wikimedia.org/wikipedia/commons/3/3f/Logo_Linux_Mint.png" height="17">&nbsp;**Linux Mint:** `sudo apt-get install build-essential`
  - <img src="http://i1-news.softpedia-static.com/images/extra/LINUX/small/slw218news1.png" height="17">&nbsp;**Fedora**: `sudo dnf groupinstall "Development Tools"`


### PR DESCRIPTION
Adds `width="17"` to match `height="17"` to Apple icon image.

Before:
![before](https://user-images.githubusercontent.com/22686684/194423463-c0ff00c7-e5d3-4ba0-91ae-564f575fc57f.png)

After:
![after](https://user-images.githubusercontent.com/22686684/194423486-24f94b0d-038d-41c8-b46d-cb87a64be0ad.png)
