### PR TITLE
refactor(docker)!: ignores .env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-FROM node:12-slim
+FROM node:16.18.0-alpine
+
+ENV NODE_ENV production
+EXPOSE 8080
 
 WORKDIR /starter
-ENV NODE_ENV development
-
-COPY package.json /starter/package.json
+COPY . /starter/
 
 RUN npm install pm2 -g
 RUN npm install --production
 
-COPY .env.example /starter/.env.example
-COPY . /starter
-
 CMD ["pm2-runtime","app.js"]
 
-EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -1293,9 +1293,11 @@ After installing docker, start the application with the following commands :
 # To build the project for the first time or when you add dependencies
 docker-compose build web
 
-# To start the application (or to restart after making changes to the source code)
-docker-compose up web
+# To start the application
+docker-compose up
 
+# To restart after making changes to the source code
+docker-compose restart web
 ```
 
 To view the app, find your docker IP address + port 8080 ( this will typically be http://localhost:8080/ ).  To use a port other than 8080, you would need to modify the port in app.js, Dockerfile, and docker-compose.yml.

--- a/app.js
+++ b/app.js
@@ -8,7 +8,6 @@ const bodyParser = require('body-parser');
 const logger = require('morgan');
 const errorHandler = require('errorhandler');
 const lusca = require('lusca');
-const dotenv = require('dotenv');
 const MongoStore = require('connect-mongo');
 const flash = require('express-flash');
 const path = require('path');
@@ -20,9 +19,12 @@ const multer = require('multer');
 const upload = multer({ dest: path.join(__dirname, 'uploads') });
 
 /**
+ * Development Mode:
  * Load environment variables from .env file, where API keys and passwords are configured.
  */
-dotenv.config({ path: '.env.example' });
+if (process.env.NODE_ENV !== 'production') {
+  require('dotenv').config({ path: '.env.example' });
+}
 
 /**
  * Controllers (route handlers).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,16 @@ services:
   web:
     build: .
     ports:
-     - "8080:8080"
+      - "8080:8080"
+    env_file:
+      - .env
     environment:
-     - MONGODB_URI=mongodb://mongo:27017/test 
+      - MONGODB_URI=mongodb://mongo:27017/test
     links:
-     - mongo 
-    depends_on: 
-     - mongo 
+      - mongo
+    depends_on:
+      - mongo
     volumes:
-     - .:/starter
-     - /starter/node_modules
-     
+      - .:/starter
+      - /starter/node_modules
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "cheerio": "^1.0.0-rc.10",
         "compression": "^1.7.4",
         "connect-mongo": "^4.6.0",
-        "dotenv": "^16.0.0",
         "errorhandler": "^1.5.1",
         "express": "^4.17.3",
         "express-flash": "^0.0.2",
@@ -69,6 +68,7 @@
       },
       "devDependencies": {
         "chai": "^4.3.6",
+        "dotenv": "^16.0.3",
         "eslint": "^8.12.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-chai-friendly": "^0.7.2",
@@ -2699,9 +2699,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
-      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -11319,9 +11320,10 @@
       }
     },
     "dotenv": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
-      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "cheerio": "^1.0.0-rc.10",
     "compression": "^1.7.4",
     "connect-mongo": "^4.6.0",
-    "dotenv": "^16.0.0",
     "errorhandler": "^1.5.1",
     "express": "^4.17.3",
     "express-flash": "^0.0.2",
@@ -77,6 +76,7 @@
   },
   "devDependencies": {
     "chai": "^4.3.6",
+    "dotenv": "^16.0.3",
     "eslint": "^8.12.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-chai-friendly": "^0.7.2",


### PR DESCRIPTION
## Dockerfile

### prevents secrets and environment variables from being baked into the Dockerfile
Secrets and other environment variables should not be baked into an image.
Instead, run the docker container with the `--env-file=` argument.
See [docker run options --env-file](https://docs.docker.com/engine/reference/commandline/run/#options)
Example:
```
docker run -p 8080:8080 --env-file=.env --link=mongo local/hackathon-starter
```

### Dockerfile base image uses matching node version

Node version in `package.json` is 16.
This other PR #1217 pins the lts/gallium node version
Dockerfile base image now uses the same node version

### Dockerfile base image uses smaller alpine os

[alpine base images are much smaller](https://nickjanetakis.com/blog/the-3-biggest-wins-when-using-alpine-as-a-base-docker-image), which also means deploys are faster.

### Dockerfile sets NODE_ENV to production

**❗️Breaking Change**

Sets the default NODE_ENV to production so that dotenv can conditionally skip loading .env

### Conditional requirement of dotenv

dotenv should not be required in production. 
if using docker, use `--env-file=` 
if using docker-compose, use
```yaml
env_file:
  - .env
```