### PR TITLE
1247 fix docker image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ ENV NODE_ENV development
 COPY package.json /starter/package.json
 
 RUN npm install pm2 -g
-RUN npm install --production
 
 COPY .env.example /starter/.env.example
 COPY . /starter
+
+RUN npm install --production --ignore-scripts
 
 CMD ["pm2-runtime","app.js"]
 


### PR DESCRIPTION
fixes #1247 

- npm install has to run after the files are copied
- had to use ` --ignore-scripts` because it was failing on husky. Husky is a devDependency but also part of the postinstall
- Everything works now with `docker compose up`