### PR TITLE
Fixes building docker image. #1247

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,12 @@ FROM node:18-slim
 
 WORKDIR /starter
 ENV NODE_ENV development
-
-COPY package.json /starter/package.json
-
-RUN npm install pm2 -g
-RUN npm install --production
-
-COPY .env.example /starter/.env.example
 COPY . /starter
 
-CMD ["pm2-runtime","app.js"]
+RUN npm install pm2 -g
+RUN npm install 
+RUN npm run scss
 
 EXPOSE 8080
+
+CMD ["pm2-runtime","app.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build: .
     ports:
      - "8080:8080"
+     - "27017:27017"
     environment:
      - MONGODB_URI=mongodb://mongo:27017/test 
     links:


### PR DESCRIPTION
Fixes building docker image #1256 
- Copy files before executing or running any commands in Dockerfile.
- Removed lines which were doing same thing in Dockfile.
- Exposing ports before running the application in Dockerfile
- Exposed another port for MongoDB to make it accessable through localhost.
- "npm install --production" has some problems with husky, using "npm install" instad for now.
- Running "npm run scss" in Dockerfile, therefore fixing fixing "404 main.css" error while running the application in docker.