### PR TITLE
change text of Stripe and Foursquare to white

### DIFF
--- a/views/api/index.pug
+++ b/views/api/index.pug
@@ -19,7 +19,7 @@ block content
             | Facebook
     .col-md-4
       a(href='/api/foursquare', style='color: #fff')
-        .card(style='background-color: #1cafec').mb-3
+        .card(style='background-color: #1cafec').text-white.mb-3
           .card-body
             img(src='https://i.imgur.com/PixH9li.png', height=40, style='padding: 0px 10px 0px 0px')
             | Foursquare
@@ -49,7 +49,7 @@ block content
             | Twitch
     .col-md-4
       a(href='/api/stripe', style='color: #fff')
-        .card(style='background-color: #3da8e5').mb-3
+        .card(style='background-color: #3da8e5').text-white.mb-3
           .card-body
             img(src='https://i.imgur.com/w3s2RvW.png', height=40, style='padding: 0px 10px 0px 0px')
             | Stripe


### PR DESCRIPTION
Fixes #1270 
**Change**
Make the text colour of "Stripe" and "Foursquare" buttons to white, in the API Examples tab.

**Reason for change**
Improve the UI by making the colours uniform. Different text and underline colours are not particularly pleasing, unless they have some use-case. I believe that this makes the UI look just a bit better, at least.

**Old UI**
![image](https://github.com/sahat/hackathon-starter/assets/66008435/14af3738-3036-4ece-a940-5c81df6c38ff)


**New UI**
![image](https://github.com/sahat/hackathon-starter/assets/66008435/b8dc2927-a3af-4e2d-849f-8dbb8c70d2ee)
