### PR TITLE
Changed text color of Foursquare and Strip

### DIFF
--- a/views/api/index.pug
+++ b/views/api/index.pug
@@ -19,7 +19,7 @@ block content
             | Facebook
     .col-md-4
       a(href='/api/foursquare', style='color: #fff')
-        .card(style='background-color: #1cafec').mb-3
+        .card(style='background-color: #1cafec').text-white.mb-3
           .card-body
             img(src='https://i.imgur.com/PixH9li.png', height=40, style='padding: 0px 10px 0px 0px')
             | Foursquare
@@ -49,7 +49,7 @@ block content
             | Twitch
     .col-md-4
       a(href='/api/stripe', style='color: #fff')
-        .card(style='background-color: #3da8e5').mb-3
+        .card(style='background-color: #3da8e5').text-white.mb-3
           .card-body
             img(src='https://i.imgur.com/w3s2RvW.png', height=40, style='padding: 0px 10px 0px 0px')
             | Stripe


### PR DESCRIPTION
This PR has changed the text color of Foursquare and Stripe on the API Examples page to maintain a good user interface and consistency in the UI. In short, make a uniform text color under the "API Examples" tab.
Code: #1270 
![ss](https://github.com/sahat/hackathon-starter/assets/71094720/983a2452-415c-4547-bc33-81dff62dd929)
