### PR TITLE
Limit husky to non-prod & Upgrade/Fix Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM node:18-slim
+FROM node:20-slim
 
 WORKDIR /starter
 ENV NODE_ENV development
 
-COPY package.json /starter/package.json
-
-RUN npm install pm2 -g
-RUN npm install --production
-
 COPY .env.example /starter/.env.example
 COPY . /starter
+
+RUN npm install pm2 -g
+RUN if [ "$NODE_ENV" = "production" ]; then \
+    npm install --omit=dev; \
+    else \
+    npm install; \
+    fi
 
 CMD ["pm2-runtime","app.js"]
 

--- a/README.md
+++ b/README.md
@@ -1180,7 +1180,7 @@ User.aggregate({ $group: { _id: null, total: { $sum: '$votes' } } }, (err, votes
 Docker
 ----------
 
-You will need docker and docker-compose installed to build the application.
+You will need to install docker and docker-compose on your system. If you are using WSL, you will need to install Docker Desktop on Windows and docker-compose on WSL.
 
 - [Docker installation](https://docs.docker.com/engine/installation/)
 
@@ -1189,8 +1189,11 @@ You will need docker and docker-compose installed to build the application.
 After installing docker, start the application with the following commands :
 
 ```
-# To build the project for the first time or when you add dependencies
+# To build the project while supressing most of the build messages
 docker-compose build web
+
+# To build the project without supressing the build messages or using cached data
+ docker-compose build --no-cache --progress=plain web
 
 # To start the application (or to restart after making changes to the source code)
 docker-compose up web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,14 @@
-version: '3'
+version: '3.8'
 services:
   mongo:
-    image: mongo:3.6
+    image: mongo
   web:
     build: .
     ports:
      - "8080:8080"
     environment:
-     - MONGODB_URI=mongodb://mongo:27017/test 
+     - MONGODB_URI=mongodb://mongo:27017/test
     links:
-     - mongo 
-    depends_on: 
-     - mongo 
-    volumes:
-     - .:/starter
-     - /starter/node_modules
-     
+     - mongo
+    depends_on:
+     - mongo

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "npm run scss && node app.js",
     "test": "nyc mocha --timeout=60000 --exit",
     "lint": "eslint \"**/*.js\"",
-    "prepare": "husky install",
+    "prepare": "if [ \"$NODE_ENV\" != \"production\" ]; then husky install; fi",
     "scss": "sass --no-source-map --load-path=./ --update ./public/css:./public/css",
     "lintStage": "node_modules/.bin/lint-staged"
   },


### PR DESCRIPTION
Upgraded the docker-compose to version 3.8.
Upgrade the docker Node.js image to 20-slim.
Set mongo image to be the latest instead of a preset version that can go out of date often. Added the ability to set the docker environment as development or production. Added a check to the package.json prepare script to only install husky’s execution in non-production environments. This prevents npm install from failing in production environments, where dev dependencies may not be installed. Husky has been a dev dependency. Fixed a bug where docker-compose was overwriting the application/build folder causing removal of css files that were built with sass. Removed the extra end of line spaces in docker-compose.yml.