### PR TITLE
Merging RUN instruction (reduced number of layers in image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 
 WORKDIR /starter
 ENV NODE_ENV development

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ ENV NODE_ENV development
 COPY .env.example /starter/.env.example
 COPY . /starter
 
-RUN npm install pm2 -g
-RUN if [ "$NODE_ENV" = "production" ]; then \
-    npm install --omit=dev; \
+RUN npm install -g pm2 && \
+    if [ "$NODE_ENV" = "production" ]; then \
+        npm install --omit=dev; \
     else \
-    npm install; \
+        npm install; \
     fi
 
 CMD ["pm2-runtime","app.js"]


### PR DESCRIPTION
Each time a RUN instruction is added, a new layer is introduced into the final image.
This has a direct impact on build time and image size. Chaining commands into a single RUN statement using && will use a single layer, thus reducing the number of layers in the image.

Issue detected by SonarQube Cloud 
On dockerfile