### PR TITLE
fix: Skip reCAPTCHA and a console warning if key is missing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ SMTP_PASSWORD=hdgfadsfahg--i.e.Sendgrid-apikey---hdgfadsfahg
 SMTP_HOST=smtp.sendgrid.net
 
 # Needed for proper rendering of the Contact Form
-RECAPTCHA_SITE_KEY=JKHGxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxJG
+RECAPTCHA_SITE_KEY=
 RECAPTCHA_SECRET_KEY=87ehxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx3298
 
 #

--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ _What to get and configure:_
   - For user workflows for reset password and verify email
   - For contact form processing
 - reCAPTCHA
-  - For contact form submission
+  - For contact form submission, but you can skip it during your development
 - OAuth for social logins (Sign in with / Login with)
   - Depending on your application need, obtain keys from Google, Facebook, X (Twitter), LinkedIn, Twitch, GitHub. You don't have to obtain valid keys for any provider that you don't need. Just remove the buttons and links in the login and account pug views before your demo.
-- API keys for service providers in the API Examples if you are planning to use them.
+- API keys for service providers that you need in the API Examples if you are planning to use them.
 
 - MongoDB Atlas
 

--- a/test/contact.js
+++ b/test/contact.js
@@ -1,0 +1,153 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const request = require('supertest');
+const express = require('express');
+const session = require('express-session');
+const contactController = require('../controllers/contact');
+
+let app;
+let sendMailStub;
+let fetchStub;
+const OLD_ENV = { ...process.env };
+
+function setupApp(controller) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use(session({ secret: 'test', resave: false, saveUninitialized: false }));
+
+  // Set a dummy CSRF token for all requests
+  app.use((req, res, next) => {
+    req.flash = (type, msg) => {
+      req.session[type] = msg;
+    };
+    req.csrfToken = () => 'testcsrf';
+    res.render = () => res.status(200).send('Contact Form');
+    next();
+  });
+
+  app.get('/contact', controller.getContact);
+  app.post('/contact', controller.postContact);
+  return app;
+}
+
+describe('Contact Controller', () => {
+  before(() => {
+    process.env.SITE_CONTACT_EMAIL = 'test@example.com';
+    process.env.RECAPTCHA_SITE_KEY = 'dummy';
+    process.env.RECAPTCHA_SECRET_KEY = 'dummy';
+  });
+
+  beforeEach(() => {
+    // Stub nodemailerConfig.sendMail
+    sendMailStub = sinon.stub().resolves();
+    // Patch require cache for nodemailerConfig
+    const nodemailerConfig = require.cache[require.resolve('../config/nodemailer')];
+    if (nodemailerConfig) {
+      nodemailerConfig.exports.sendMail = sendMailStub;
+    }
+
+    // Stub global fetch for reCAPTCHA
+    fetchStub = sinon.stub().resolves({
+      json: () => Promise.resolve({ success: true }),
+    });
+    global.fetch = fetchStub;
+
+    app = setupApp(contactController);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    if (sendMailStub) sendMailStub.resetHistory();
+    delete global.fetch;
+  });
+
+  after(() => {
+    process.env = OLD_ENV;
+  });
+
+  describe('GET /contact', () => {
+    it('renders the contact form', (done) => {
+      request(app)
+        .get('/contact')
+        .expect(200)
+        .end((err) => {
+          if (err) return done(err);
+          expect(true).to.be.true; // keep assertion for lint, actual check is above
+          done();
+        });
+    });
+  });
+
+  describe('POST /contact', () => {
+    it('rejects missing name/email for unknown user', (done) => {
+      request(app)
+        .post('/contact')
+        .type('form')
+        .send({ _csrf: 'testcsrf', name: '', email: '', message: 'Hello', 'g-recaptcha-response': 'token' })
+        .expect(302)
+        .expect('Location', '/contact')
+        .end((err) => {
+          if (err) return done(err);
+          expect(sendMailStub.called).to.be.false;
+          done();
+        });
+    });
+
+    it('rejects missing message', (done) => {
+      request(app)
+        .post('/contact')
+        .type('form')
+        .send({ _csrf: 'testcsrf', name: 'Test', email: 'test@example.com', message: '', 'g-recaptcha-response': 'token' })
+        .expect(302)
+        .expect('Location', '/contact')
+        .end((err) => {
+          if (err) return done(err);
+          expect(sendMailStub.called).to.be.false;
+          done();
+        });
+    });
+
+    it('rejects missing reCAPTCHA', (done) => {
+      request(app)
+        .post('/contact')
+        .type('form')
+        .send({ _csrf: 'testcsrf', name: 'Test', email: 'test@example.com', message: 'Hello', 'g-recaptcha-response': '' })
+        .expect(302)
+        .expect('Location', '/contact')
+        .end((err) => {
+          if (err) return done(err);
+          expect(sendMailStub.called).to.be.false;
+          done();
+        });
+    });
+
+    it('sends email if all fields are valid', (done) => {
+      request(app)
+        .post('/contact')
+        .type('form')
+        .send({ _csrf: 'testcsrf', name: 'Test', email: 'test@example.com', message: 'Hello', 'g-recaptcha-response': 'token' })
+        .expect(302)
+        .expect('Location', '/contact')
+        .end((err) => {
+          if (err) return done(err);
+          expect(sendMailStub.calledOnce).to.be.true;
+          done();
+        });
+    });
+
+    it('handles reCAPTCHA failure', (done) => {
+      fetchStub.resolves({ json: () => Promise.resolve({ success: false }) });
+      request(app)
+        .post('/contact')
+        .type('form')
+        .send({ _csrf: 'testcsrf', name: 'Test', email: 'test@example.com', message: 'Hello', 'g-recaptcha-response': 'token' })
+        .expect(302)
+        .expect('Location', '/contact')
+        .end((err) => {
+          if (err) return done(err);
+          expect(sendMailStub.called).to.be.false;
+          done();
+        });
+    });
+  });
+});

--- a/views/contact.pug
+++ b/views/contact.pug
@@ -1,13 +1,14 @@
 extends layout
 
 block head
-  script(src='https://www.google.com/recaptcha/api.js', async='', defer='')
+  if sitekey
+    script(src='https://www.google.com/recaptcha/api.js', async='', defer='')
 
 block content
   .pb-2.mt-2.mb-4.border-bottom
     h3 Contact Form
 
-  form(method='POST')
+  form#contactForm(method='POST')
     input(type='hidden', name='_csrf', value=_csrf)
     if (unknownUser)
       .form-group.row.mb-3
@@ -24,8 +25,20 @@ block content
         textarea#message.form-control(name='message', rows='7', autofocus=(!unknownUser).toString(), required)
     .form-group
       .offset-md-2.col-md-8.p-1
-        .g-recaptcha(data-sitekey=sitekey)
+        if sitekey
+          #recaptchaWidget.g-recaptcha(data-sitekey=sitekey)
+          span#recaptchaError.text-danger.d-none.mt-2 Please complete the reCAPTCHA before submitting the form.
         br
-        button.col-md-2.btn.btn-primary(type='submit')
+        button#submitBtn.col-md-2.btn.btn-primary(type='submit')
           i.far.fa-envelope.fa-sm.iconpadding
           | Send
+  script.
+    document.getElementById('contactForm').addEventListener('submit', function (event) {
+      const recaptchaError = document.getElementById('recaptchaError');
+      if (typeof grecaptcha !== 'undefined' && !grecaptcha.getResponse()) {
+        event.preventDefault(); // Prevent form submission
+        recaptchaError.classList.remove('d-none');
+      } else {
+        recaptchaError.classList.add('d-none');
+      }
+    });


### PR DESCRIPTION
Don't block developers if they don't have a reCAPTCHA key; notify them in the console to add one before going to production.