### PR TITLE
chore: remove Airbnb ESLint fork in favor of direct rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,19 +1,14 @@
 import chaiFriendly from 'eslint-plugin-chai-friendly';
 import globals from 'globals';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import airbnbConfig from 'eslint-config-airbnb-base-extract/airbnb-config.mjs';
 import eslintConfigPrettier from 'eslint-config-prettier/flat';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import eslintPluginImport from 'eslint-plugin-import';
 
 export default [
-  ...airbnbConfig,
   eslintConfigPrettier,
   {
     plugins: {
       'chai-friendly': chaiFriendly,
+      import: eslintPluginImport,
     },
 
     languageOptions: {
@@ -21,19 +16,64 @@ export default [
         ...globals.node,
         ...globals.mocha,
       },
-      ecmaVersion: 2022,
+      //ecmaVersion: 2022,  // was needed to override outdated airbnb configs, the default is latest
+      sourceType: 'module',
     },
 
     rules: {
-      'consistent-return': 0,
-      'no-param-reassign': 0,
-      'no-underscore-dangle': 0,
-      'no-shadow': 0,
-      'no-console': 0,
-      'no-plusplus': 0,
-      'no-unused-expressions': 0,
+      'global-require': 'error',
+      // Airbnb-specific restrictions
+      strict: ['error', 'never'],
+      'import/no-unresolved': ['error', { commonjs: true, caseSensitive: true }],
+      'import/extensions': ['error', 'ignorePackages', { js: 'never', mjs: 'never', jsx: 'never' }],
+      'import/order': ['error', { groups: [['builtin', 'external', 'internal']], distinctGroup: true }],
+      'import/no-duplicates': 'error',
+      'import/prefer-default-export': 'error',
+
+      // Code style enforcement from Airbnb
+      'arrow-body-style': ['error', 'as-needed'],
+      'arrow-parens': ['error', 'always'],
+      'brace-style': ['error', '1tbs'],
+      'eol-last': ['error', 'always'],
+      indent: ['error', 2],
+      'object-curly-spacing': ['error', 'always'],
+      'quote-props': ['error', 'as-needed'],
+      semi: ['error', 'always'],
+      'space-before-blocks': ['error', 'always'],
+      'space-in-parens': ['error', 'never'],
+
+      // Other strict Airbnb rules
+      curly: ['error', 'multi-line'],
+      'dot-notation': 'error',
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
+      'no-alert': ['warn'],
+      'no-else-return': ['error', { allowElseIf: false }],
+      'no-eval': 'error',
+      'no-loop-func': 'error',
+      'no-multi-spaces': 'error',
+      'no-new': 'error',
+      'no-restricted-properties': ['error', { object: 'Math', property: 'pow', message: 'Use ** instead.' }],
+      'no-return-assign': ['error', 'always'],
+      'no-self-compare': 'error',
+      'prefer-template': 'error',
+      radix: 'error',
+
+      // Skipping some potential Airbnb rules
+      //'camelcase': ['error'],
+      //'comma-dangle': ['error', { arrays: 'always-multiline', objects: 'always-multiline' }],
+      //'quotes': ['error', 'single', { avoidEscape: true }],
+      //'max-len': ['error', 100],
+
+      // Prior overrides, some of which may not be necessary
+      //'consistent-return': 'off',
+      //'no-param-reassign': 'off',
+      //'no-underscore-dangle': 'off',
+      //'no-shadow': 'off',
+      //'no-console': 'off',
+      //'no-plusplus': 'off',
+      //'no-unused-expressions': 'off',
       'no-unused-vars': ['error', { argsIgnorePattern: 'next' }],
-      'chai-friendly/no-unused-expressions': 2,
+      'chai-friendly/no-unused-expressions': 'error',
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "c8": "^10.1.3",
     "chai": "^5.2.0",
     "eslint": "^9.26.0",
-    "eslint-config-airbnb-base-extract": "github:SeattleDevs/eslint-config-airbnb-base-extract",
     "eslint-config-prettier": "^10.1.3",
     "eslint-plugin-chai-friendly": "^1.0.1",
     "eslint-plugin-import": "^2.31.0",


### PR DESCRIPTION
The project previously transitioned from Airbnb's ESLint rules to a maintained fork due to the original rules falling behind. This commit removes the dependency on Airbnb entirely, opting instead to directly include the necessary linting rules for better maintainability and flexibility moving forward.