### PR TITLE
update: removed sendgrid from readme and env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ TRANSACTION_EMAIL=youremail-OR-noreply@yourdomain.com
 SESSION_SECRET=Your Session Secret goes here
 
 SMTP_USER=apikey
-SMTP_PASSWORD=hdgfadsfahg--i.e.Sendgrid-apikey---hdgfadsfahg
-SMTP_HOST=smtp.sendgrid.net
+SMTP_PASSWORD=your-smtp-password
+SMTP_HOST=your-smtp-host
 
 # Needed for proper rendering of the Contact Form
 RECAPTCHA_SITE_KEY=

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ I also tried to make it as **generic** and **reusable** as possible to cover mos
   - Verify Email
   - Link multiple OAuth provider accounts to one account
   - Delete Account
-- Contact Form (powered by SMTP via Sendgrid, Mailgun, AWS SES, etc.)
+- Contact Form (powered by SMTP via Mailgun, AWS SES, etc.)
 - File upload
 - Device camera
 - **AI Examples and Boilerplates**
@@ -196,7 +196,6 @@ Obtain SMTP credentials from a provider for transactional emails. Set the SMTP_U
 
 | Provider | Free Tier                  | Website                 |
 | -------- | -------------------------- | ----------------------- |
-| SendGrid | 100 emails/day for free    | https://sendgrid.com    |
 | SMTP2Go  | 1000 emails/month for free | https://www.smtp2go.com |
 | Brevo    | 300 emails/day for free    | https://www.brevo.com   |
 
@@ -1236,6 +1235,8 @@ class Person {
 ```js
 Math.floor(Date.now() / 1000);
 ```
+
+
 
 ```MomentJS
 moment().unix();


### PR DESCRIPTION
@sahat kindly check.

### CHANGES

_env.example_
```
- SMTP_PASSWORD=hdgfadsfahg--i.e.Sendgrid-apikey---hdgfadsfahg
- SMTP_HOST=smtp.sendgrid.net

changed:
+ SMTP_PASSWORD=your-smtp-password
+ SMTP_HOST=your-smtp-host
```


_README.md_

- Contact Form (powered by SMTP via Sendgrid, Mailgun, AWS SES, etc.)
+ Contact Form (powered by SMTP via Mailgun, AWS SES, etc.)

**removed this in table:**
| SendGrid | 100 emails/day for free    | https://sendgrid.com    |