### PR TITLE
improved the readme.md  and docker with followed instructions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,28 @@ version: '3.8'
 services:
   mongo:
     image: mongo
+    volumes:
+      - mongo-data:/data/db
   web:
     build: .
     ports:
       - '8080:8080'
+    env_file:
+      - .env
     environment:
       - MONGODB_URI=mongodb://mongo:27017/test
-    links:
-      - mongo
+
     depends_on:
       - mongo
+  ngrok:
+    image: ngrok/ngrok:latest
+    ports:
+      - '4040:4040'
+    environment:
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
+    command: 'http web:8080'
+    depends_on:
+      - web
+
+volumes:
+  mongo-data:


### PR DESCRIPTION
I've made some updates to our Docker configuration and README to make local development smoother and more practical, especially when working with OAuth.

Here’s a quick rundown of what’s changed:

*Key Improvements*

--Integrated ngrok for Easy OAuth: I've added an ngrok service to the [docker-compose.yml](code-assist-path:/Users/priyabratasingh/Downloads/hacktoberfest25/hackathon-starter/docker-compose.yml). This automatically creates a secure public URL for our local instance, which is a huge help for testing OAuth providers that require an HTTPS callback URL. No more fighting with localtunnel or manual setups!
Persistent MongoDB Data: The MongoDB container now uses a named volume to store its data. This means you won't lose all your users and test data every time you run docker compose down.
Clear, Step-by-Step Instructions: I completely rewrote the Docker section in the [README.md](code-assist-path:/Users/priyabratasingh/Downloads/hacktoberfest25/hackathon-starter/README.md). The new guide walks you through the setup process step-by-step, from creating the .env file to getting the ngrok URL and starting the services in the right order.

*Why These Changes Matter*

--The previous Docker setup was a bit too basic and didn't work out-of-the-box for features that need a public endpoint (like most of our API integrations). These changes create a much more realistic and robust development environment that mirrors how we'd use the app in production.

Plus, the new documentation should make it way easier for new contributors (and us!) to get up and running quickly.

Let me know what you think