### PR TITLE
Add e2e tests for web scraping

### DIFF
--- a/test/e2e/scraping.e2e.test.js
+++ b/test/e2e/scraping.e2e.test.js
@@ -1,0 +1,24 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Web Scraping Integration', () => {
+  test('should display scraped Hacker News links with proper page structure', async ({ page }) => {
+    await page.goto('/api/scraping');
+    await page.waitForLoadState('networkidle');
+
+    // Verify page basics
+    await expect(page).toHaveTitle(/Web Scraping/);
+    await expect(page.locator('h2')).toContainText('Web Scraping');
+    await expect(page.locator('h3')).toContainText('Hacker News Frontpage');
+
+    // Verify table exists with headers
+    const table = page.locator('table.table.table-condensed');
+    await expect(table).toBeVisible();
+    await expect(page.locator('thead tr th').nth(0)).toContainText('№');
+    await expect(page.locator('thead tr th').nth(1)).toContainText('Title');
+
+    // Verify scraped data
+    const tableRows = page.locator('tbody tr');
+    const rowCount = await tableRows.count();
+    expect(rowCount).toBeGreaterThan(25); // usually the list is ~30
+  });
+});


### PR DESCRIPTION
Fixes - #1429 
### Changes
Added checks for -
- page basics
- table exists with headers
- num of links must be greater than 25

Screenshot of the console output -
<img width="1198" height="789" alt="image" src="https://github.com/user-attachments/assets/ef3c5a35-2a2d-465c-9327-6f553c4d8c37" />

Screenshot of webpage - 
<img width="681" height="879" alt="image" src="https://github.com/user-attachments/assets/ecb751f8-d0be-421a-a911-daf588a1f596" />

