### PR TITLE
test(e2e): add comprehensive Last.fm API integration tests

### DIFF
--- a/test/e2e/lastfm.e2e.test.js
+++ b/test/e2e/lastfm.e2e.test.js
@@ -1,0 +1,283 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Last.fm API Integration', () => {
+  test('should launch app, navigate to Last.fm API page, and handle API response', async ({ page }) => {
+    // Navigate to Last.fm API page
+    await page.goto('/api/lastfm');
+    await page.waitForLoadState('networkidle');
+
+    // Basic page checks
+    await expect(page).toHaveTitle(/Last\.fm API/);
+    await expect(page.locator('h2')).toContainText('Last.fm API');
+
+    // Check for API documentation links
+    await expect(page.locator('.btn-group a[href*="lastfm-node"]')).toBeVisible();
+    await expect(page.locator('.btn-group a[href*="last.fm/api/account/create"]')).toBeVisible();
+    await expect(page.locator('.btn-group a[href="http://www.last.fm/api"]')).toBeVisible();
+
+    // Detect if API returned an error (rate limit, API key issues, etc.)
+    const errorElement = page.locator('text=/error|rate limit|invalid|unauthorized/i');
+    const isError = (await errorElement.count()) > 0;
+
+    if (isError) {
+      // Verify error handling works
+      console.log('Last.fm API error detected - testing error handling');
+      await expect(page.locator('body')).toContainText(/error|rate limit|invalid|unauthorized/i);
+    } else {
+      // Verify normal content rendering - artist name should be visible
+      console.log('Last.fm API call succeeded - testing content display');
+
+      // Check artist name (should be "Roniit" based on controller)
+      const artistName = page.locator('h3');
+      await expect(artistName).toBeVisible({ timeout: 10000 });
+      await expect(artistName).toContainText('Roniit');
+
+      // Check Top Albums section
+      const topAlbumsHeading = page.locator('h4', { hasText: 'Top Albums' });
+      await expect(topAlbumsHeading).toBeVisible();
+
+      // Check for album images (should have at least one)
+      const albumImages = page.locator('img[src*="lastfm"]');
+      await expect(albumImages.first()).toBeVisible();
+
+      // Check Tags section
+      const tagsHeading = page.locator('h4', { hasText: 'Tags' });
+      await expect(tagsHeading).toBeVisible();
+
+      // Check for tag elements
+      const tagElements = page.locator('span.label.label-primary');
+      await expect(tagElements.first()).toBeVisible();
+
+      // Check Biography section
+      const biographyHeading = page.locator('h4', { hasText: 'Biography' });
+      await expect(biographyHeading).toBeVisible();
+
+      // Biography should either have content or "No biography" message
+      const biographyContent = page.locator('h4:has-text("Biography") + p');
+      await expect(biographyContent).toBeVisible();
+
+      // Check Top Tracks section
+      const topTracksHeading = page.locator('h4', { hasText: 'Top Tracks' });
+      await expect(topTracksHeading).toBeVisible();
+
+      // Check for track list (ordered list)
+      const trackList = page.locator('ol');
+      await expect(trackList).toBeVisible();
+
+      // Check for track links
+      const trackLinks = page.locator('ol li a[href*="last.fm"]');
+      await expect(trackLinks.first()).toBeVisible();
+
+      // Check Similar Artists section
+      const similarArtistsHeading = page.locator('h4', { hasText: 'Similar Artists' });
+      await expect(similarArtistsHeading).toBeVisible();
+
+      // Check for similar artist links
+      const similarArtistsList = page.locator('ul.list-unstyled.list-inline');
+      await expect(similarArtistsList).toBeVisible();
+
+      const similarArtistLinks = page.locator('ul.list-unstyled.list-inline li a[href*="last.fm"]');
+      await expect(similarArtistLinks.first()).toBeVisible();
+    }
+  });
+
+  test('should display correct page structure and navigation elements', async ({ page }) => {
+    await page.goto('/api/lastfm');
+    await page.waitForLoadState('networkidle');
+
+    // Check page title and main heading
+    await expect(page).toHaveTitle(/Last\.fm API/);
+    await expect(page.locator('h2')).toContainText('Last.fm API');
+
+    // Verify the Last.fm icon is present
+    const lastfmIcon = page.locator('i.far.fa-play-circle');
+    await expect(lastfmIcon).toBeVisible();
+    await expect(lastfmIcon).toHaveCSS('color', 'rgb(219, 19, 2)'); // #db1302
+
+    // Check all three documentation buttons
+    const buttons = page.locator('.btn-group.d-flex .btn');
+    await expect(buttons).toHaveCount(3);
+
+    // Verify button texts and links
+    await expect(page.locator('a[href*="lastfm-node"]')).toContainText('Last.fm Node Docs');
+    await expect(page.locator('a[href*="api/account/create"]')).toContainText('Create API Account');
+    await expect(page.locator('a[href="http://www.last.fm/api"]')).toContainText('API Endpoints');
+
+    // Verify all buttons open in new tab
+    const docLinks = page.locator('.btn-group a');
+    const linkCount = await docLinks.count();
+    for (let i = 0; i < linkCount; i++) {
+      await expect(docLinks.nth(i)).toHaveAttribute('target', '_blank');
+    }
+  });
+
+  test('should test Last.fm API endpoint directly and verify data structure', async ({ request, page }) => {
+    await page.goto('/api/lastfm');
+    await page.waitForLoadState('networkidle');
+
+    // Test the API endpoint directly
+    const response = await request.get('/api/lastfm');
+    expect(response.ok()).toBeTruthy();
+
+    // Verify page content matches expected data structure
+    // Artist name should be present
+    const artistNameElement = page.locator('h3');
+    await expect(artistNameElement).toBeVisible();
+
+    // Check that all main sections are present
+    const sections = ['Top Albums', 'Tags', 'Biography', 'Top Tracks', 'Similar Artists'];
+
+    for (const section of sections) {
+      await expect(page.locator(`h4:has-text("${section}")`)).toBeVisible();
+    }
+
+    // Verify track list has items (should have up to 10 tracks based on controller)
+    const trackItems = page.locator('ol li');
+    const trackCount = await trackItems.count();
+    expect(trackCount).toBeGreaterThan(0);
+    expect(trackCount).toBeLessThanOrEqual(10);
+
+    // Verify album images are present (should have up to 3 albums based on controller)
+    const albumImages = page.locator('h4:has-text("Top Albums") ~ img');
+    const albumCount = await albumImages.count();
+    expect(albumCount).toBeGreaterThanOrEqual(0);
+    expect(albumCount).toBeLessThanOrEqual(3);
+
+    // Verify tags are present and properly formatted
+    const tags = page.locator('span.label.label-primary');
+    if ((await tags.count()) > 0) {
+      await expect(tags.first()).toContainText(/\w+/); // Should contain text
+      await expect(tags.first().locator('i.fas.fa-tag')).toBeVisible();
+    }
+
+    // Verify similar artists links work properly
+    const similarArtistLinks = page.locator('ul.list-unstyled.list-inline li a');
+    if ((await similarArtistLinks.count()) > 0) {
+      await expect(similarArtistLinks.first()).toHaveAttribute('href', /last\.fm/);
+    }
+
+    // Verify track links work properly
+    const trackLinks = page.locator('ol li a');
+    if ((await trackLinks.count()) > 0) {
+      await expect(trackLinks.first()).toHaveAttribute('href', /last\.fm/);
+    }
+  });
+
+  test('should handle missing or empty data gracefully', async ({ page }) => {
+    await page.goto('/api/lastfm');
+    await page.waitForLoadState('networkidle');
+
+    // Check biography section - should handle empty bio gracefully
+    const biographySection = page.locator('h4:has-text("Biography")');
+    await expect(biographySection).toBeVisible();
+
+    // Biography should either have content or show "No biography"
+    const biographyContent = page.locator('h4:has-text("Biography") + p');
+    await expect(biographyContent).toBeVisible();
+
+    // If no biography, should show appropriate message
+    const noBioMessage = page.locator('p:has-text("No biography")');
+    const hasBioContent = page.locator('h4:has-text("Biography") + p:not(:has-text("No biography"))');
+
+    // One of these should be true
+    const noBioExists = (await noBioMessage.count()) > 0;
+    const bioExists = (await hasBioContent.count()) > 0;
+    expect(noBioExists || bioExists).toBeTruthy();
+  });
+
+  test('should verify all external links have correct attributes', async ({ page }) => {
+    await page.goto('/api/lastfm');
+    await page.waitForLoadState('networkidle');
+
+    // Check documentation links
+    const docLinks = page.locator('.btn-group a');
+    const docLinkCount = await docLinks.count();
+
+    for (let i = 0; i < docLinkCount; i++) {
+      const link = docLinks.nth(i);
+      await expect(link).toHaveAttribute('target', '_blank');
+      const href = await link.getAttribute('href');
+      expect(href).toMatch(/^https?:\/\//); // Should be absolute URLs
+    }
+
+    // Check track links (if present)
+    const trackLinks = page.locator('ol li a');
+    const trackLinkCount = await trackLinks.count();
+
+    for (let i = 0; i < Math.min(trackLinkCount, 3); i++) {
+      // Check first 3 to avoid timeout
+      const link = trackLinks.nth(i);
+      const href = await link.getAttribute('href');
+      expect(href).toContain('last.fm');
+    }
+
+    // Check similar artist links (if present)
+    const artistLinks = page.locator('ul.list-unstyled.list-inline li a');
+    const artistLinkCount = await artistLinks.count();
+
+    for (let i = 0; i < Math.min(artistLinkCount, 3); i++) {
+      // Check first 3 to avoid timeout
+      const link = artistLinks.nth(i);
+      const href = await link.getAttribute('href');
+      expect(href).toContain('last.fm');
+    }
+  });
+
+  test('should verify artist data elements are properly displayed', async ({ page }) => {
+    await page.goto('/api/lastfm');
+    await page.waitForLoadState('networkidle');
+
+    // Detect if we have successful API response
+    const artistName = page.locator('h3');
+    const hasArtistData = (await artistName.count()) > 0;
+
+    if (hasArtistData) {
+      // Test artist name display
+      await expect(artistName).toBeVisible();
+      await expect(artistName).toContainText(/\w+/); // Should contain at least one word
+
+      // Test album images have proper src attributes
+      const albumImages = page.locator('img[src*="lastfm"], img[src*="last.fm"]');
+      if ((await albumImages.count()) > 0) {
+        const firstImage = albumImages.first();
+        await expect(firstImage).toHaveAttribute('width', '240');
+        await expect(firstImage).toHaveAttribute('height', '240');
+      }
+
+      // Test tag formatting
+      const tagElements = page.locator('span.label.label-primary');
+      if ((await tagElements.count()) > 0) {
+        const firstTag = tagElements.first();
+        await expect(firstTag.locator('i.fas.fa-tag')).toBeVisible();
+        await expect(firstTag).toContainText(/\w+/); // Should contain text
+      }
+
+      // Test track list structure
+      const trackList = page.locator('ol');
+      if ((await trackList.count()) > 0) {
+        const trackItems = page.locator('ol li');
+        const firstTrack = trackItems.first();
+        await expect(firstTrack).toBeVisible();
+
+        const trackLink = firstTrack.locator('a');
+        if ((await trackLink.count()) > 0) {
+          await expect(trackLink).toHaveAttribute('href', /last\.fm/);
+        }
+      }
+
+      // Test similar artists structure
+      const similarArtistsList = page.locator('ul.list-unstyled.list-inline');
+      if ((await similarArtistsList.count()) > 0) {
+        const artistItems = page.locator('ul.list-unstyled.list-inline li');
+        if ((await artistItems.count()) > 0) {
+          const firstArtist = artistItems.first();
+          const artistLink = firstArtist.locator('a');
+          if ((await artistLink.count()) > 0) {
+            await expect(artistLink).toHaveAttribute('href', /last\.fm/);
+            await expect(artistLink).toContainText(/\w+/); // Should contain text
+          }
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Add end-to-end tests for Last.fm API integration covering:
- Basic page structure and navigation
- API response handling (success/error cases)
- Data structure verification
- External link validation
- Graceful handling of missing data

<img width="1696" height="943" alt="image" src="https://github.com/user-attachments/assets/917957c5-d659-40e9-96ee-17da256c28fa" />
