### PR TITLE
feat: add hash versioning for client side main.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,8 @@
  * Module dependencies.
  */
 const path = require('node:path');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
 const express = require('express');
 const compression = require('compression');
 const session = require('express-session');
@@ -206,6 +208,12 @@ app.use('/js/lib', express.static(path.join(__dirname, 'node_modules/jquery/dist
 app.use('/js/lib', express.static(path.join(__dirname, 'node_modules/@simplewebauthn/browser/dist/bundle'), { maxAge: 31557600000 }));
 app.use('/webfonts', express.static(path.join(__dirname, 'node_modules/@fortawesome/fontawesome-free/webfonts'), { maxAge: 31557600000 }));
 app.use('/image-cache', express.static(path.join(__dirname, 'tmp/image-cache'), { maxAge: 31557600000 }));
+
+app.locals.mainJsHash = crypto
+  .createHash('md5') // only used as a cache buster, so md5 is sufficient and faster than sha256
+  .update(fs.readFileSync(path.join(__dirname, 'public', 'js', 'main.js')))
+  .digest('hex')
+  .slice(0, 8);
 
 /**
  * Analytics IDs needed thru layout.pug; set as express local so we don't have to pass them with each render call

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -27,7 +27,7 @@ html.h-100(lang='en')
 
     script(src='/js/lib/jquery.min.js')
     script(src='/js/lib/bootstrap.min.js')
-    script(src='/js/main.js')
+    script(src='/js/main.js?v=' + mainJsHash)
     script(src='https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js')
 
     script(type='text/javascript').


### PR DESCRIPTION
<!-- IMPORTANT: maintainers may close PRs that fail the checks below without review. -->

## Checklist

- [x] I acknowledge that submissions that include copy-paste of AI-generated content taken at face value (PR text, code, commit message, documentation, etc.) most likely have errors and hence will be rejected entirely and marked as spam or invalid
- [x] I manually tested the change with a running instance, DB, and valid API keys where applicable
- [x] Added/updated tests if the existing tests do not cover this change
- [x] README or other relevant docs are updated
- [x] `--no-verify` was not used for the commit(s)
- [x] `npm run lint` passed locally without any errors
- [x] `npm test` passed locally without any errors
- [x] `npm run test:e2e:replay` passed locally without any errors
- [x] `npm run test:e2e:custom -- --project=chromium-nokey-live` passed locally without any errors
- [x] PR diff does not include unrelated changes
- [x] PR title follows Conventional Commits — https://www.conventionalcommits.org/en

## Description
Without versioning for the client-side js files, the web browser caching or proxy caching (i.e. Cloudflare) may continue serving an outdated `main.js` causing friction during development.

## Screenshots of UI changes (browser) and logs/test results (console, terminal, shell, cmd)
N/A